### PR TITLE
adding comment for wrong pagination start

### DIFF
--- a/src/main/java/org/osiam/client/query/Query.java
+++ b/src/main/java/org/osiam/client/query/Query.java
@@ -79,11 +79,12 @@ public class Query {
      */
     public Query previousPage() {
         int newIndex = getStartIndex() - getCount();
+        
         if (newIndex < DEFAULT_INDEX) {
             throw new IllegalStateException("Negative startIndex is not possible.");
         }
-        String prevIndex = "startIndex=" + newIndex;
-        return new Query(indexMatcher.replaceFirst("" + prevIndex));
+        
+        return new Query(indexMatcher.replaceFirst("startIndex=" + newIndex));
     }
 
 


### PR DESCRIPTION
The Scim spec defines the minimal startIndex for pagination as 1, but currently OSIAM server uses an 0-based pagination. A comment was added to address this issue.
