### PR TITLE
[enhancement] removed sonatype parent and clearify maven profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,22 +21,17 @@
     ~ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
     ~ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-    </parent>
 
     <groupId>org.osiam</groupId>
     <artifactId>connector4java</artifactId>
     <version>1.2-SNAPSHOT</version>
-    <name>OSIAM Connector 4 Java</name>
-    <packaging>jar</packaging>
 
+    <name>OSIAM Connector 4 Java</name>
+    <description>Native Java API to connect to the REST based OSIAM services</description>
+    <url>https://github.com/osiam/connector4java</url>
     <licenses>
         <license>
             <name>The MIT License (MIT)</name>
@@ -45,18 +40,15 @@
         </license>
     </licenses>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
-        <java.version>1.7</java.version>
-        <sonar.core.codeCoveragePlugin>cobertura</sonar.core.codeCoveragePlugin>
-        <!-- force sonar to reuse reports generated during build cycle -->
-        <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
-        <!-- Explicitly define property so we don't end up with literal string if it's not set -->
-        <!-- We need a value, too. Otherwise (if the property tag is empty) the arguments definition -->
-        <!-- in the sonatype parent pom is merged. -->
-        <release.arguments>-Ddo-not-trigger-sonatype-oss-release-profile-by-default</release.arguments>
-    </properties>
+    <developers>
+        <developer>
+            <name>OSIAM Team</name>
+            <email>info@osiam.org</email>
+            <timezone>+1</timezone>
+            <organization>tarent solutions GmbH</organization>
+            <organizationUrl>http://www.tarent.de</organizationUrl>
+        </developer>
+    </developers>
 
     <scm>
         <connection>scm:git://git@github.com/osiam/connector4java.git</connection>
@@ -65,30 +57,13 @@
         <tag>HEAD</tag>
     </scm>
 
-    <developers>
-        <developer>
-            <id>trossn</id>
-            <name>Thorsten Rossner</name>
-            <email>info@osiam.org</email>
-            <timezone>+1</timezone>
-            <organization>OSIAM</organization>
-        </developer>
-    </developers>
-
-    <distributionManagement>
-
-        <repository>
-            <id>osiam-repository</id>
-            <name>public evolvis release repository</name>
-            <url>scpexe://maven-repo.evolvis.org:/var/www/maven_repo/releases</url>
-        </repository>
-        <snapshotRepository>
-            <id>OSIAM-NG-SNAPSHOT-repository</id>
-            <name>public evolvis release repository</name>
-            <url>scpexe://maven-repo.evolvis.org:/var/www/maven_repo/snapshots/</url>
-        </snapshotRepository>
-
-    </distributionManagement>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.7</java.version>
+        <sonar.core.codeCoveragePlugin>cobertura</sonar.core.codeCoveragePlugin>
+        <!-- force sonar to reuse reports generated during build cycle -->
+        <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
+    </properties>
 
     <dependencies>
 
@@ -140,87 +115,8 @@
     </dependencies>
 
     <build>
-        <extensions>
-            <extension>
-                <groupId>org.apache.maven.wagon</groupId>
-                <artifactId>wagon-ssh-external</artifactId>
-                <version>2.6</version>
-            </extension>
-        </extensions>
         <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                </configuration>
-            </plugin>
-
-            <!-- Needed to publish releases to sonatype staging repo -->
-            <!-- which leads to maven central -->
-            <!-- Note: In order for this to work you need to have the -->
-            <!-- appropriate server tag in your .m2/settings.xml -->
-            <!-- with your username/password for the sonatype jira -->
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <id>default-deploy</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>deploy</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <serverId>sonatype-nexus-staging</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                </configuration>
-            </plugin>
-            <!-- Needed due to a problem with SSH -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.1</version>
-                <executions>
-                    <execution>
-                        <id>default-deploy</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>deploy</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <!-- During release:perform, enable the "release" profile -->
-            <plugin>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5</version>
-                <configuration>
-                    <!-- During release:perform, enable the "release" profile -->
-                    <releaseProfiles>sonatype-oss-release</releaseProfiles>
-                    <arguments>-Psonatype-oss-release ${release.arguments}</arguments>
-                    <goals>deploy</goals>
-                </configuration>
-            </plugin>
-
-            <!-- Surefire: will execute all unit tests including Spock specs and will ignore system tests -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.16</version>
-                <configuration>
-                    <argLine>-XX:-UseSplitVerifier</argLine>
-                    <trimStackTrace>false</trimStackTrace>
-                    <includes>
-                        <include>**/*Test.*</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            <!-- enforce to user maven 3.0.4 -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
@@ -242,6 +138,42 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.5</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+
+            <!-- Surefire: will execute all unit tests including Spock specs and will ignore system tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.16</version>
+                <configuration>
+                    <argLine>-XX:-UseSplitVerifier</argLine>
+                    <trimStackTrace>false</trimStackTrace>
+                    <includes>
+                        <include>**/*Test.*</include>
+                    </includes>
+                </configuration>
+            </plugin>
+
             <!-- Shade all dependencies for compatibility reasons -->
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -254,14 +186,22 @@
                         </goals>
                         <configuration>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
-                                        <resource>META-INF/services/org.glassfish.hk2.extension.ServiceLocatorGenerator</resource>
+                                        <resource>
+                                            META-INF/services/org.glassfish.hk2.extension.ServiceLocatorGenerator
+                                        </resource>
                                     </resources>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
-                                    <resource>META-INF/services/org.osiam.bundled.org.glassfish.hk2.extension.ServiceLocatorGenerator</resource>
-                                    <file>${project.basedir}/src/main/shade/org.osiam.bundled.org.glassfish.hk2.extension.ServiceLocatorGenerator</file>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                    <resource>
+                                        META-INF/services/org.osiam.bundled.org.glassfish.hk2.extension.ServiceLocatorGenerator
+                                    </resource>
+                                    <file>
+                                        ${project.basedir}/src/main/shade/org.osiam.bundled.org.glassfish.hk2.extension.ServiceLocatorGenerator
+                                    </file>
                                 </transformer>
                             </transformers>
                             <artifactSet>
@@ -348,106 +288,12 @@
                 </executions>
             </plugin>
         </plugins>
-
-        <!-- override sonatype parent pom settings by default -->
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5</version>
-                    <inherited>false</inherited>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-
     </build>
 
     <profiles>
-        <!-- ==================== Profile: release ==================== -->
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <!-- During release:perform, enable the "release" profile -->
-                    <!--
-                        ~ Extra parameters are passed using the "release.arguments" property on the command line.
-                        ~ In Jenkins configure Maven release build / Release goals and options (in one line):
-                        ~ -Dresume=false release:clean release:prepare release:perform
-                        ~ -Drelease.arguments="-Dgpg.passphrase=$PASSPHRASE -Dgpg.keyname=Signing\\ Key "
-                        ~ (Take care of proper quoting/escaping: Spaces within the key's uid have to be escaped!)
-                    -->
-                    <plugin>
-                        <artifactId>maven-release-plugin</artifactId>
-                        <version>2.5</version>
-                        <configuration>
-                            <arguments>-Psonatype-oss-release ${release.arguments}</arguments>
-                            <goals>deploy</goals>
-                        </configuration>
-                    </plugin>
-
-                    <!-- Needed to publish releases to sonatype staging repo -->
-                    <!-- which leads to maven central -->
-                    <!-- Note: In order for this to work you need to have the -->
-                    <!-- appropriate server tag in your .m2/settings.xml -->
-                    <!-- with your username/password for the sonatype jira -->
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6</version>
-                        <extensions>true</extensions>
-                        <executions>
-                            <execution>
-                                <id>default-deploy</id>
-                                <phase>deploy</phase>
-                                <goals>
-                                    <goal>deploy</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <serverId>sonatype-nexus-staging</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                        </configuration>
-                    </plugin>
-
-                </plugins>
-            </build>
-        </profile>
-
-        <!-- ==================== Profile: sign ==================== -->
-        <profile>
-            <id>sign</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <!-- call as "mvn verify -Dgpg.passphrase=thephrase" or set -Dgpg.skip=true -->
-                    <!-- If not given, gpg passphrase has to be provided interactively -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
         <!-- ==================== Profile: coverage ==================== -->
         <profile>
             <id>coverage</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
             <build>
                 <plugins>
                     <plugin>
@@ -476,11 +322,10 @@
             </build>
         </profile>
 
-        <!-- ==================== Profile: build internally for integration runs ==================== -->
-        <!-- Deployment needs to be run from jenkins server which has credentials to access the internal repository -->
+        <!-- ==================== Profile: build internally for snapshot runs ==================== -->
+        <!-- Deployment needs to be run from jenkins server which has credentials to access the internal snapshot repository -->
         <profile>
-            <id>integration</id>
-
+            <id>snapshot</id>
             <distributionManagement>
                 <repository>
                     <id>osiam-repository</id>
@@ -488,20 +333,11 @@
                     <url>scpexe://maven-repo.evolvis.org:/var/www/maven_repo/releases</url>
                 </repository>
                 <snapshotRepository>
-                    <id>OSIAM-NG-SNAPSHOT-repository</id>
-                    <name>public evolvis release repository</name>
-                    <url>scpexe://maven-repo.evolvis.org:/var/www/maven_repo/snapshots/</url>
+                    <id>osiam-snapshot-repository</id>
+                    <name>public evolvis snapshot repository</name>
+                    <url>scpexe://maven-repo.evolvis.org:/var/www/maven_repo/snapshots</url>
                 </snapshotRepository>
-
             </distributionManagement>
-
-            <repositories>
-                <repository>
-                    <id>osiam releases repo</id>
-                    <url>https://maven-repo.evolvis.org/releases</url>
-                </repository>
-            </repositories>
-
             <build>
                 <plugins>
                     <plugin>
@@ -524,6 +360,70 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!-- ==================== Profile: build for release runs ==================== -->
+        <profile>
+            <id>release</id>
+            <distributionManagement>
+                <repository>
+                    <id>sonatype-nexus-staging</id>
+                    <name>Nexus Release Repository</name>
+                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                </repository>
+            </distributionManagement>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>2.3</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.7</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-release-plugin</artifactId>
+                        <version>2.5</version>
+                        <configuration>
+                            <arguments>-Prelease ${release.arguments}</arguments>
+                            <tagNameFormat>v@{project.version}</tagNameFormat>
+                            <mavenExecutorId>forked-path</mavenExecutorId>
+                            <useReleaseProfile>false</useReleaseProfile>
+                            <goals>deploy</goals>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
- adjusted pom to maven code convention: http://maven.apache.org/developers/conventions/code.html
- introduced updated profile 'release', to release the connector4java to maven central, without the load of the sonatype parent pom
- updated integration profile to snapshot profile
- updated developer to the OSIAM team dev
- changed release tag from connector4java-{version} to v{version}, like the other OSIAM projects
