### PR TITLE
[fix] after shading the jar the tests are missing dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,8 +107,22 @@
 
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
+            <artifactId>hamcrest-all</artifactId>
             <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib-nodep</artifactId>
+            <version>3.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.objenesis</groupId>
+            <artifactId>objenesis</artifactId>
+            <version>2.1</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
- The second test run fails after the jar was shaded, because of ClassNotFoundException
- Added cglib-nodep and objenesis dependency
