### PR TITLE
[fix] cobertura fails due to wrong phase binding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,7 @@
                         <executions>
                             <execution>
                                 <id>generate-data</id>
-                                <phase>package</phase>
+                                <phase>test</phase>
                                 <goals>
                                     <goal>cobertura</goal>
                                 </goals>


### PR DESCRIPTION
after introducing the shading of this artifact, the cobertura code
coverage utility was unable to run the tests on the instrumented
classes. this was caused by the shade plugin which changes the current
model used by the maven run and excluded all transitive test-scoped
dependencies. due to a misconfiguration the cobertura plugin ran in the
package phase after the shade plugin changed the model. fixed this by
binding the cobertura lifecycle execution to the test phase. also reverted
the previous workaround.
