### PR TITLE
Small clean-ups for code hygiene

### DIFF
--- a/src/main/java/org/osiam/client/AbstractOsiamService.java
+++ b/src/main/java/org/osiam/client/AbstractOsiamService.java
@@ -101,7 +101,7 @@ abstract class AbstractOsiamService<T extends Resource> {
             throw new ConnectionInitializationException(CONNECTION_SETUP_ERROR_STRING, e);
         }
 
-        checkAndHandleResponse(content, status, accessToken, "get", id);
+        checkAndHandleResponse(content, status, accessToken, "get");
 
         return mapToResource(content);
     }
@@ -137,11 +137,11 @@ abstract class AbstractOsiamService<T extends Resource> {
             throw new ConnectionInitializationException(CONNECTION_SETUP_ERROR_STRING, e);
         }
 
-        checkAndHandleResponse(content, status, accessToken, String.format("search with query: %s", query), null);
+        checkAndHandleResponse(content, status, accessToken, String.format("search with query: %s", query));
 
         try {
             JavaType queryResultType = TypeFactory.defaultInstance()
-                    .constructParametricType(SCIMSearchResult.class, type);
+                    .constructParametrizedType(SCIMSearchResult.class, SCIMSearchResult.class, type);
 
             return mapper.readValue(content, queryResultType);
         } catch (IOException e) {
@@ -166,7 +166,7 @@ abstract class AbstractOsiamService<T extends Resource> {
             throw new ConnectionInitializationException(CONNECTION_SETUP_ERROR_STRING, e);
         }
 
-        checkAndHandleResponse(content, status, accessToken, "delete", id);
+        checkAndHandleResponse(content, status, accessToken, "delete");
     }
 
     protected T createResource(T resource, AccessToken accessToken) {
@@ -193,7 +193,7 @@ abstract class AbstractOsiamService<T extends Resource> {
             throw new ConnectionInitializationException(CONNECTION_SETUP_ERROR_STRING, e);
         }
 
-        checkAndHandleResponse(content, status, accessToken, "create", null);
+        checkAndHandleResponse(content, status, accessToken, "create");
 
         return mapToResource(content);
     }
@@ -231,7 +231,7 @@ abstract class AbstractOsiamService<T extends Resource> {
             throw new ConnectionInitializationException(CONNECTION_SETUP_ERROR_STRING, e);
         }
 
-        checkAndHandleResponse(content, status, accessToken, method.equals("PUT") ? "replace" : "update", id);
+        checkAndHandleResponse(content, status, accessToken, method.equals("PUT") ? "replace" : "update");
 
         return mapToResource(content);
     }
@@ -248,8 +248,7 @@ abstract class AbstractOsiamService<T extends Resource> {
         }
     }
 
-    protected void checkAndHandleResponse(String content, StatusType status, AccessToken accessToken, String action,
-            String id) {
+    protected void checkAndHandleResponse(String content, StatusType status, AccessToken accessToken, String action) {
         if (status.getFamily() == Family.SUCCESSFUL) {
             return;
         }

--- a/src/main/java/org/osiam/client/OsiamUserService.java
+++ b/src/main/java/org/osiam/client/OsiamUserService.java
@@ -85,7 +85,7 @@ class OsiamUserService extends AbstractOsiamService<User> { // NOSONAR - Builder
             throw new ConnectionInitializationException(CONNECTION_SETUP_ERROR_STRING, e);
         }
 
-        checkAndHandleResponse(content, status, accessToken, "get me", null);
+        checkAndHandleResponse(content, status, accessToken, "get me");
 
         return mapToType(content, BasicUser.class);
     }

--- a/src/main/java/org/osiam/client/helper/ScopeDeserializer.java
+++ b/src/main/java/org/osiam/client/helper/ScopeDeserializer.java
@@ -29,21 +29,19 @@ import java.util.Set;
 import org.osiam.client.oauth.Scope;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 
 public class ScopeDeserializer extends JsonDeserializer<Set<Scope>> {
 
     @Override
-    public Set<Scope> deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException,
-            JsonProcessingException {
+    public Set<Scope> deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
         String text = jp.getText();
         return parseParameterList(text);
     }
 
     private Set<Scope> parseParameterList(String values) {
-        Set<Scope> scopeResult = new HashSet<Scope>();
+        Set<Scope> scopeResult = new HashSet<>();
         if (values != null && values.trim().length() > 0) {
             String[] scopes = values.split("\\s+");
             for (String scope : scopes) {

--- a/src/main/java/org/osiam/client/helper/ScopeSerializer.java
+++ b/src/main/java/org/osiam/client/helper/ScopeSerializer.java
@@ -29,17 +29,15 @@ import java.util.Set;
 import org.osiam.client.oauth.Scope;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 
 public class ScopeSerializer extends JsonSerializer<Set<Scope>> {
 
     @Override
-    public void serialize(Set<Scope> value, JsonGenerator jgen, SerializerProvider provider) throws IOException,
-            JsonProcessingException {
+    public void serialize(Set<Scope> value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
         if (value != null && !value.isEmpty()) {
-            StringBuffer scopeResult = new StringBuffer();
+            StringBuilder scopeResult = new StringBuilder();
             for (Scope scope : value) {
                 scopeResult.append(scope).append(" ");
             }


### PR DESCRIPTION
This pull request is a little clean up of the code base.
 - Replaces a deprecated method call with its intended successor
 - Removes an unused parameter from a protected method
 - Removes declared exceptions from signatures if broader parent exceptions are already defined
 - Uses the diamond inference since java 7 is required
 - replaces an unnecessary use of StringBuffer with StringBuilder for performance.