### PR TITLE
Eagerly Create the Services in the Constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # OSIAM Connector4Java
 
-## 1.7 - 2015-09-09
+## 1.7 - 2015-09-10
 
 ### Changes
 
 - Update scim-schema to solve performance issues when deserializing `User`s
 - Deprecate old, method-based scopes (GET, POST, PUT, PATCH, DELETE)
 - Adjust the client to the SCIM compliant errors (Compatibility with OSIAM <= 2.x is provided)
+- Throws `IllegalStateException` when using a non-configured service endpoint
+  was `InvalidAttributeException`
 
 ## 1.6 - 2015-06-17
 

--- a/src/test/java/org/osiam/client/AuthServiceTest.java
+++ b/src/test/java/org/osiam/client/AuthServiceTest.java
@@ -23,21 +23,19 @@
 
 package org.osiam.client;
 
-import org.junit.Test;
-import org.osiam.client.exception.InvalidAttributeException;
-import org.osiam.client.oauth.Scope;
+import static com.jcabi.matchers.RegexMatchers.containsPattern;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLEncoder;
 
-import static com.jcabi.matchers.RegexMatchers.containsPattern;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import org.junit.Test;
+import org.osiam.client.oauth.Scope;
 
 public class AuthServiceTest {
 
@@ -62,18 +60,6 @@ public class AuthServiceTest {
                 "%s/oauth/authorize?client_id=%s&response_type=code&redirect_uri=%s&scope=%s",
                 ENDPOINT, VALID_CLIENT_ID, REDIRECT_URI, encodeExpectedString(Scope.ADMIN.toString())));
         assertThat(redirectUri, is(equalTo(expectedUri)));
-    }
-
-    @Test(expected = InvalidAttributeException.class)
-    public void request_access_token_without_setting_endpoint_raises_exception() {
-        OsiamConnector oConnector = new OsiamConnector.Builder()
-                .setClientId(VALID_CLIENT_ID)
-                .setClientSecret(VALID_CLIENT_SECRET)
-                .build();
-
-        oConnector.retrieveAccessToken();
-
-        fail("Exception expected");
     }
 
     @Test

--- a/src/test/java/org/osiam/client/OsiamConnectorTest.java
+++ b/src/test/java/org/osiam/client/OsiamConnectorTest.java
@@ -1,0 +1,24 @@
+package org.osiam.client;
+
+import org.junit.Test;
+
+public class OsiamConnectorTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void throws_illegal_state_exception_when_no_resource_server_is_configured_and_user_is_retrieved() {
+        OsiamConnector connector = new OsiamConnector.Builder().setAuthServerEndpoint("irrelevant").build();
+        connector.getUser("irrelevant", null);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void throws_illegal_state_exception_when_no_resource_server_is_configured_and_group_is_retrieved() {
+        OsiamConnector connector = new OsiamConnector.Builder().setAuthServerEndpoint("irrelevant").build();
+        connector.getGroup("irrelevant", null);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void throws_illegal_state_exception_when_no_auth_server_is_configured_and_access_token_is_retrieved() {
+        OsiamConnector connector = new OsiamConnector.Builder().setResourceServerEndpoint("irrelevant").build();
+        connector.retrieveAccessToken("irrelevant");
+    }
+}

--- a/src/test/java/org/osiam/client/OsiamUserServiceTest.java
+++ b/src/test/java/org/osiam/client/OsiamUserServiceTest.java
@@ -59,14 +59,14 @@ public class OsiamUserServiceTest {
     }
 
     @Test(expected = NullPointerException.class)
-    public void accessToken_is_null_by_getting_single_user_raises_exception() throws Exception {
+    public void access_token_is_null_by_getting_single_user_raises_exception() throws Exception {
         service.getUser(searchedID, null);
 
         fail("Exception expected");
     }
 
     @Test(expected = NullPointerException.class)
-    public void accessToken_is_null_by_getting_all_group_raises_exception() throws Exception {
+    public void access_token_is_null_by_getting_all_group_raises_exception() throws Exception {
         service.getAllUsers(null);
 
         fail("Exception expected");
@@ -80,7 +80,7 @@ public class OsiamUserServiceTest {
     }
 
     @Test(expected = NullPointerException.class)
-    public void create_user_with_null_accestoken_raises_exception() {
+    public void create_user_with_null_access_token_raises_exception() {
         User newUser = new User.Builder("irrelevant").build();
 
         service.createUser(newUser, null);
@@ -96,10 +96,9 @@ public class OsiamUserServiceTest {
     }
 
     @Test(expected = NullPointerException.class)
-    public void delete_user_with_null_accestoken_raises_exception() {
+    public void delete_user_with_null_access_token_raises_exception() {
         service.deleteUser("irrelevant", null);
 
         fail("Exception excpected");
     }
-
 }


### PR DESCRIPTION
This commit moves the object creation into the constructor because the
lazy initialization was not thread-safe and does not provide any
benefits.