### PR TITLE
Always update snapshots on CircleCI builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,6 @@
+dependencies:
+  override:
+    - mvn -U dependency:resolve dependency:resolve-plugins
 test:
   override:
     - mvn verify


### PR DESCRIPTION
We had some issues building the current development version on CircleCI.  As it turned out, Maven did not use the latest snapshots of some dependencies, but our code depended on these new versions. This commit adds the `-U` switch to the 'dependencies' phase of CircleCI, so that snapshots will always be updated, and also enables downloading of the plugins, so that they will be cached too.

Fixes #164