### PR TITLE
Restore compatibility with old Jackson versions

### DIFF
--- a/src/main/java/org/osiam/client/AbstractOsiamService.java
+++ b/src/main/java/org/osiam/client/AbstractOsiamService.java
@@ -142,9 +142,8 @@ abstract class AbstractOsiamService<T extends Resource> {
         checkAndHandleResponse(content, status, accessToken);
 
         try {
-            JavaType queryResultType = TypeFactory.defaultInstance()
-                    .constructParametrizedType(SCIMSearchResult.class, SCIMSearchResult.class, type);
-
+            JavaType queryResultType =
+                    TypeFactory.defaultInstance().constructParametricType(SCIMSearchResult.class, type);
             return mapper.readValue(content, queryResultType);
         } catch (IOException e) {
             throw new OsiamClientException(String.format("Unable to deserialize search result: %s", content), e);


### PR DESCRIPTION
Jackson 2.5 introduced new methods to `TypeFactory` that the connector is using to deserialize a SCIM search result. Not everybody has updated to Jackson >= 2.5, so incompatibilities have arisen. This commit restores the usage of the old, but deprecated method to construct a proper `JavaType` instance. It will call the new method anyway.