### PR TITLE
Handle Bad Username Password Credentials

### DIFF
--- a/src/main/java/org/osiam/client/AuthService.java
+++ b/src/main/java/org/osiam/client/AuthService.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Strings;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
+import org.osiam.client.exception.BadCredentialsException;
+import org.osiam.client.exception.BadRequestException;
 import org.osiam.client.exception.ClientAlreadyExistsException;
 import org.osiam.client.exception.ClientNotFoundException;
 import org.osiam.client.exception.ConflictException;
@@ -489,7 +491,11 @@ class AuthService {
 
         if (status.getStatusCode() == Status.BAD_REQUEST.getStatusCode()) {
             String errorMessage = extractErrorMessage(content, status);
-            throw new ConnectionInitializationException(errorMessage);
+            if (errorMessage.equals("Bad credentials")) {
+                throw new BadCredentialsException(content);
+            } else {
+                throw new BadRequestException(errorMessage);
+            }
         } else if (status.getStatusCode() == Status.UNAUTHORIZED.getStatusCode()) {
             String errorMessage = extractErrorMessage(content, status);
             throw new UnauthorizedException(errorMessage);

--- a/src/main/java/org/osiam/client/exception/BadCredentialsException.java
+++ b/src/main/java/org/osiam/client/exception/BadCredentialsException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2013 tarent AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.osiam.client.exception;
+
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+
+public class BadCredentialsException extends OsiamRequestException {
+
+    private static final long serialVersionUID = 6032774491343587869L;
+
+    public BadCredentialsException(String message) {
+        super(SC_BAD_REQUEST, message);
+    }
+}

--- a/src/main/java/org/osiam/client/exception/BadRequestException.java
+++ b/src/main/java/org/osiam/client/exception/BadRequestException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2013 tarent AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.osiam.client.exception;
+
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+
+public class BadRequestException extends OsiamRequestException {
+
+    private static final long serialVersionUID = 3405113109715390926L;
+
+    public BadRequestException(String message) {
+        super(SC_BAD_REQUEST, message);
+    }
+}


### PR DESCRIPTION
Introducing two new exceptions:
- `BadRequestExceptions`: Thrown when the auth-server returns 400/BadRequest
  instead of the before thrown `ConnectionInitializationException`
- `BadCredentialsException`: Thrown when the auth-server returns 400/BadRequest
  but with "Bad credentials" response body.

Resolves #117