### PR TITLE
Migrate from wiki to markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,19 +91,19 @@
 
 ## 1.0 - 2014-05-15
 Finally released version 1.0 of all important OSIAM projects!
-- [enhancement] You can check if an accesstoken is valid
+- [enhancement] You can check if an access token is valid
 - [enhancement] AccessToken provides additional information about the user it belongs to and the
   expiration date of the refresh token. The AccessToken can be created with a Builder.
 - [refactor] The OsiamConnector.Builder doesn't need all information to create an AccessToken. You can set
   the needed information directly in the retrieveAccessToken(...) methods. The OsiamConnector provides one
   retrieveAccessToken-method for each grant
-  For detailed information: https://github.com/osiam/connector4java/wiki/Migration#from-015-to-10
+  For detailed information, please checkout the [migration](migration.md#from-015-to-10)
 
 ## 0.15 - 2014-04-30
 - [feature] added class StringQueryBuilder
 - [feature] added class QueryHelper
 - [refactor] renaming some methods in the OsiamConnector.Builder
-  For detailed information: https://github.com/osiam/connector4java/wiki/Migration#from-014-to-015
+  For detailed information, please checkout the [migration](migration.md#from-014-to-015)
 
 ## 0.14 - 2014-04-02
 - [enhancement] Raised SCIM-Schema version to 0.41. No migration necessary.
@@ -113,6 +113,6 @@ Finally released version 1.0 of all important OSIAM projects!
 
 ## 0.13 - 2014-02-14
 - [feature] OSNG-215 - Develop PATCH "Delete" support on extensions
-  For migration see: https://github.com/osiam/connector4java/wiki/Migration#wiki-from-012-to-013
+  For migration see: [migration](migration.md#from-012-to-013)
 - Updating a user is only possible by using an UpdateUser, updating with User is not supported anymore
-  https://github.com/osiam/connector4java/wiki/Migration#wiki-from-012-to-013
+  [migration](migration.md#from-012-to-013)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # connector4java [![Circle CI](https://circleci.com/gh/osiam/connector4java.svg?style=svg)](https://circleci.com/gh/osiam/connector4java)
 
-For detailed information and documentation visit the [connector4java Wiki]
-(https://github.com/osiam/connector4java/wiki).
+For more information and documentation please take a look in the
+[docs](docs/README.md).
 
 If you are interested to use the OSIAM connector4java please watch or, even
-better, join us on Github.
+better, join us on GitHub.
 
 ## Overview
 
@@ -18,10 +18,10 @@ login for Java.
 ## Short OSIAM introduction
 
 OSIAM provides an easy and secure oauth2 standard login of users. It is also
-possible to asign users to groups with different roles.
+possible to assign users to groups with different roles.
 
 It is possible to run a dedicated OSIAM User and Group Server or to connect to
-an existing identitiy provider (like login over facebook).
+an existing identity provider (like login over facebook).
 
 OSIAM provides three different ways to log in:
 
@@ -53,7 +53,7 @@ It is
 ## OSIAM Connector for Java
 
 The connector4java enables easy and convenient use of OSIAM authentication and
-user management in a Java enviroment.
+user management in a Java environment.
 
 It provides a easy to use API, a step by step documentation how to set up a test
 system and also offers different “ready to go” examples that should enable the

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+# Welcome to the connector4java documentation!
+
+This is the central place for the OSIAM connector4java documentation. For
+detailed information please have a look in the several sections.
+
+The most recent version can be found at [maven central](http://search.maven.org/#search|ga|1|osiam).
+
+## Cross categories
+* [connector4java Overview](overview.md)
+* [integrate connector4java in your project](integration.md)
+
+## [API documentation](api-documentation.md)
+
+## [Migration](migration.md)
+
+## Related projects
+* [OSIAM](https://github.com/osiam/osiam)
+* [OSIAM SCIM User/Groups] (https://github.com/osiam/scim-schema)
+* [Facebook Login for OSIAM](https://github.com/osiam/osiam/blob/master/docs/facebook-connect.md)
+* [More about OSIAM Connectors](https://github.com/osiam/osiam/blob/master/docs/osiam-connectors.md)

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -1,0 +1,32 @@
+# [Create an OsiamConnector](create-osiam-connector.md)
+- [Scopes](create-osiam-connector.md#scopes)
+- [Grants](create-osiam-connector.md#grants)
+
+# [Login and getting an access token](login-and-getting-an-access-token.md)
+- [Access token overview](login-and-getting-an-access-token.md#access-token-overview)
+- [Retrieving an access token](login-and-getting-an-access-token.md#retrieving-an-access-token)
+
+# [User](working-with-user.md)
+- [User Object](working-with-user.md#user)
+- [Create a User](working-with-user.md#create-a-user)
+- [Delete a User](working-with-user.md#delete-a-user)
+- [Update a User](working-with-user.md#update-a-user)
+- [Retrieve a single User](working-with-user.md#retrieve-a-single-user)
+- [Retrieve the currently logged in User by his access token](working-with-user.md#retrieve-the-current-logged-in-user-by-his-access-token)
+- [Retrieve all User](working-with-user.md#retrieve-all-users)
+- [Search for Users](working-with-user.md#search-for-user)
+
+# [Group](working-with-groups.md)
+- [Group Object](working-with-groups.md#group)
+- [Creating a Group](working-with-groups.md#create-a-group)
+- [Deleting a Group](working-with-groups.md#delete-a-group)
+- [Update a Group](working-with-groups.md#update-a-group)
+- [Retrieve a single Group](working-with-groups.md#retrieve-a-single-group)
+- [Retrieve all Groups](working-with-groups.md#retrieve-all-groups)
+- [Search for groups](working-with-groups.md#search-for-groups)
+
+# [Query](query.md)
+- [Creating a Query Object](query.md#creating-a-query-object)
+- [Query.Builder](query.md#querybuilder)
+
+# [Exceptions](exceptions.md)

--- a/docs/create-osiam-connector.md
+++ b/docs/create-osiam-connector.md
@@ -1,0 +1,38 @@
+To be able to log in, and create or change users or groups you need to create
+an `org.osiam.client.connector.OsiamConnector` instance. You can do this by
+using the `OsiamConnector.Builder()` class.
+
+```java
+OsiamConnector osiamConnector = new OsiamConnector.Builder()
+       .setAuthServerEndpoint(AUTH_ENDPOINT_ADDRESS)
+       .setResourceServerEndpoint(RESOURCE_ENDPOINT_ADDRESS)
+       .setClientId(CLIENT_ID)
+       .setClientSecret(CLIENT_SECRET)
+       .build();
+```
+
+In case your auth and resource server are located at the same location and
+follow the specified naming convention you can also use:
+
+```java
+OsiamConnector osiamConnector = new OsiamConnector.Builder()
+       .setEndpoint(SERVER_ENDPOINT_ADDRESS)
+       .setClientId(CLIENT_ID)
+       .setClientSecret(CLIENT_SECRET)
+       .build();
+```
+
+## Timeouts
+
+(since 1.4) You can also set the connect and read timeouts like this:
+
+```java
+OsiamConnector.setConnectTimeout(2500);
+OsiamConnector.setReadTimeout(5000);
+```
+
+As you might noticed, these settings are application-global, so you can only
+define them for **all** connectors you create. This will be addressed in a
+future version, but note that it is recommended to use only **one** connector
+instance for the whole application, unless you need to use different OAuth
+clients.

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -1,0 +1,66 @@
+The OSIAM Connector4Java provides different own exceptions to provide a easy
+way to handle the different reasons of failure.
+
+Each Exception contains a individual code and a Exception message.
+
+The exceptions are:
+
+- [OsiamClientException](exceptions.md#osiamclientexception)
+  - [InvalidAttributeException](exceptions.md#invalidattributeexception)
+  - [ConnectionInitializationException](exceptions.md#connectioninitializationexception)
+  - [OsiamRequestException] (exceptions.md#osiamrequestexception)
+     - [ConflictException] (exceptions.md#conflictexception)
+     - [ForbiddenException] (exceptions.md#forbiddenexception)
+     - [NoResultException] (exceptions.md#noresultexception)
+     - [UnauthorizedException] (exceptions.md#unauthorizedexception)
+
+- [Individual error messages and codes](exceptions.md#error-messages-and-codes)
+
+## OsiamClientException
+
+OsiamClientException is the base exception and extends RuntimeException.
+
+### InvalidAttributeException
+
+The InvalidAttributeException extends the OsiamClientException and will be
+thrown if an invalid argument has been given (e.g. an AccessToken that is null).
+
+### ConnectionInitializationException
+
+The ConnectionInitializationException extends the OsiamClientException and will
+be thrown if no connection to the OSIAM server could be created.
+
+### OsiamRequestException
+
+The OsiamRequestException extends the OsiamClientException. It is the base
+exception of all exceptions that indicate that the connection to the server was
+successful but something else went wrong. This and all child exceptions will
+also provide a method to retrieve the HTTP status code which raised the
+exception. 
+
+    int getHttpStatusCode()
+
+This exception will be raised if an unknown error is returned by the server.
+Known errors are represented by child exceptions described below.
+
+#### ConflictException
+
+The ConflictException extends the OsiamRequestException and will be thrown if
+any conflicts happened while processing the request on the server (HTTP status
+code 409).
+
+#### ForbiddenException
+
+The ForbiddenException extends the OsiamRequestException and will be thrown if
+you are not allowed to do the requested task (HTTP status code 403).
+
+#### NoResultException
+
+The NoResultException extends the OsiamRequestException and will be thrown if a
+User/Group which wants to be created or deleted do not exist (HTTP status code
+404).
+
+#### UnauthorizedException
+
+The UnauthorizedException extends OsiamRequestException and will be thrown if
+you are not authorized to do the requested task (HTTP status code 401).

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,8 @@
+To be able to use OSIAM in your project you need to do the following things.
+
+Install OSIAM. The needed information can be found [here]
+(https://github.com/osiam/osiam/blob/master/docs/detailed-reference-installation.md).
+
+Include the OSIAM connector4java and the scim schema in your pom.xml. Both
+dependencies can be found [here](http://search.maven.org/#search|ga|1|osiam).
+

--- a/docs/login-and-getting-an-access-token.md
+++ b/docs/login-and-getting-an-access-token.md
@@ -1,0 +1,127 @@
+# Login
+
+For general information about the different OAuth 2.0 grant types please see
+the [Overview of Osiam]
+(https://github.com/osiam/osiam/blob/master/docs/OSIAM-Overview.md#oauth-20).
+A more technical explanation can be found in the [API documentation]
+(https://github.com/osiam/auth-server/blob/master/docs/api_documentation.md#oauth2).
+
+Table of contents
+- [Retrieving an access token](login-and-getting-an-access-token.md#retrieving-an-access-token)
+   - [Authorization Code Grant](login-and-getting-an-access-token.md#authorization-code-grant)
+   - [Resource Owner Password Credentials Grant](login-and-getting-an-access-token.md#resource-owner-password-credentials-grant)
+   - [Client Credentials Grant](login-and-getting-an-access-token.md#client-credentials-grant)
+- [Access token overview](login-and-getting-an-access-token.md#access-token-overview)
+
+# Scopes
+
+You access token will have some scopes to grant access to the different
+procedures.
+
+The supported scopes in OSIAM are listed [here](https://github.com/osiam/auth-server/blob/master/docs/api_documentation
+.md#supported-scopes)
+
+With **new Scope("your scope");** you can also create and add your own scopes that you need an your application
+
+# Retrieving an access token
+
+In a trusted environment getting an access token from the OAuth 2.0 server
+implies a successful login of the user. 
+
+## [Authorization Code Grant](https://github.com/osiam/auth-server/blob/master/docs/api_documentation.md#authorization-code-grant)
+
+The authorization code grant should always be used as default grant, as other
+grants are less secure and should only be used if you know what you are doing.
+
+It takes to steps to get an access token using the authorization code grant:
+
+1. Redirect the user to the OAuth 2.0 server and let the user login. You will
+get an **auth code**.
+2. Send the auth code to the OAuth 2.0 in exchange for the access token.
+
+To do so follow these steps:
+
+* Get the connector object
+
+    OsiamConnector oConnector = [Retrieving an OsiamConnector](create-osiam-connector.md#grant-authorization-code)
+
+* Redirect the user to the Auth Server. You can get the redirect URI with the
+following command:
+
+    URI redirectURI = oConnector.getRedirectLoginUri(Scope.GET, Scope.PUT);
+
+* After the user is successfully authenticated the auth server redirects the
+user back to your application's redirect URI.
+
+* If everything went fine you will receive the following parameter
+
+    <YOUR_REDIRECT_URI>?code=<AUTHENTICATION_CODE> // For example: https://localhost/?code=KkYz8C
+
+* Otherwise you get a different redirect with parameters containing more details about the situation
+
+    <YOUR_REDIRECT_URI>?error=access_denied&error_description=User+denied+access
+
+* Send the auth code to the auth server in order to get the access token
+
+    AccessToken accessToken = oConnector.retrieveAccessToken(<AUTHENTICATION_CODE>);	
+
+A complete simple Example written with vert.x can be found [here]
+(vertx-example.md)
+
+If you got the token of AccessToken as simple String you also can create an
+AccessToken the following way
+
+    AccessToken accessToken = new AccessToken.Builder(<token>).build();
+
+## [Resource Owner Password Credentials Grant](https://github.com/osiam/auth-server/blob/master/docs/api_documentation.md#resource-owner-password-credentials-grant) 
+and
+## [Client Credentials Grant](https://github.com/osiam/auth-server/blob/master/docs/api_documentation.md#client-credentials-grant)
+
+The OSIAM Connector4java allows you to retrieve an
+**org.osiam.client.oauth.accessToken**. The access token is required to access
+protected resources like an user's e-mail address.
+ 
+To retrieve an access token Object, you have to create an OsiamConnector Object
+first.
+
+    OsiamConnector oConnector = [Retrieving an OsiamConnector]
+    (create-osiam-connector.md#resource-owner-password-credentials-grant)
+
+Now it is possible to retrieve a valid access token.
+
+In case you want an AccessToken for an '**Client Credentials Grant**' you just
+can call the method by providing the needed scopes.
+
+    AccessToken accessToken = oConnector.retrieveAccessToken(Scope.GET, Scope.PUT, ...);
+
+In case you want an AccessToken for an '**Resource Owner Password Credentials
+Grant**' you also have to provide the userName and the userPassword
+
+    AccessToken accessToken = oConnector.retrieveAccessToken(<userName>, <userPassword>, Scope.GET, Scope.PUT, ...);
+
+# Refresh of an AccessToken
+
+Depending of the client configuration it is possible to refresh an AccessToken
+after it is expired. You need an can refresh an AccessToken if the following is
+true:
+
+    if(accessToken.isExpired() == true && accessToken.isRefreshTokenExpired() == false) 
+
+in this case you can refresh the AccessToken with the OsiamConnector
+
+    OsiamConnector oConnector = [Retrieving an OsiamConnector]
+    (create-osiam-connector.md#resource-owner-password-credentials-grant)
+
+# Access token overview
+
+Some of the main methods in an Access Token are:
+
+```java
+accessToken.isExpired(); // true if the accessToken is expired
+accessToken.getRefreshToken(); // gets a token that you will need if you want to refresh the token
+accessToken.isRefreshTokenExpired(); // true if the refresh token in the AccessToken is expired and the user needs to login again
+accessToken.getScopes(); //A Set of all scope of the token 
+accessToken.isClientOnly(); // true if the AccessToke was created in a "Client Credential flow" and no User belongs to it
+accessToken.getUserId(); // returns the id of the user the AccessToken belongs to
+accessToken.getUserName(); // returns the userName of the user the AccessToken belongs to 
+```

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,26 @@
+# from 0.15 to 1.0
+* Instead of setting the authentication information in the
+OsiamConnector.Builder, you have to set them in the retrieveAccessToken method.
+Beware of using the retrieveAccessToken without params. In this case, you get a
+client access token without any scopes.
+* The StringQueryBuilder changed to QueryBuilder, please check the javadoc or
+documentation for more information how to use it.
+
+# from 0.14 to 0.15
+* The method setAuthServiceEndpoint in the OsiamConnector.Build renamed to
+setAuthServerEndpoint
+* The method setResourceEndpoint in the OsiamConnector.Build renamed to
+setResourceServerEndpoint
+
+# from 0.13 to 0.14
+* No migration needed
+
+# from 0.12 to 0.13
+* UpdateUser and UpdateGroup moved to scim schema project
+* Update the user only possible with UpdateUser
+* Scim User and UpdateUser can handle extensions
+
+# from 0.11 to 0.12
+The replaceUser method of the OsiamConnector now also has the uuid of the user
+that will be replaced as first parameter, like the updateUser method:
+replaceUser(user, accessToken) to replaceUser(uuid, user, accessToken)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,35 @@
+The Connector4java is a client for [OSIAM](https://github.com/osiam/osiam)
+and provides an easy to use Java API that enables user logins or the
+administration of users, groups and their interactions.
+
+OSIAM provides a time limited access token that regulates the access to
+resources at any one time.
+For this purpose the Connector4java API enables an easy way to retrieve this
+token on different ways depending on your rights at the OSIAM server.
+
+More information about the login, retrieving an access token and the possible
+grants can be found [here](login-and-getting-an-access-token.md).
+
+# What can be done with the Connector?
+
+## [Login](login-and-getting-an-access-token.md#login)
+
+- Login by providing user name and password of an user, if you want to have
+your own login page
+
+## [Access token](login-and-getting-an-access-token.md#retrieving-an-accesstoken)
+
+Retrieval of information:
+- access token after the user's or client's login
+- if the actual access token is still valid
+- the scopes (rights) of your actual access token
+
+## [User](working-with-user.md)
+
+Retrieval of
+- single users, lists of users and the actual logged-in users
+
+## [Group](working-with-groups.md)
+
+Retrieval of
+- single groups, lists of groups and members of a group

--- a/docs/query.md
+++ b/docs/query.md
@@ -1,0 +1,110 @@
+If you want to search for Users or Groups you need to create an Query object
+
+The QueryBuilder will help you to build the needed query to get any search
+result you need. The Query object also gives you the possibility to move to the
+next or the prevision page.
+
+
+Chapters:
+- [Creating a Query Object](#creating-a-query-object)
+- [QueryBuilder](#querybuilder)
+  - [creating the filter (where) statement](#creating-the-filter-where-statement)
+  - [sorting](#sorting)
+  - [results per page](#results-per-page)
+  - [start index](#start-index)
+
+# Creating a Query Object
+A Query Object can be created by
+
+```h
+Query query = new QueryBuilder().....build();
+```
+
+
+If you have more Users or Groups than one page will hold (default 100) you can
+get with
+
+```java
+Query newQuery = query.nextPage();
+```
+
+a new query which will gives you the results of the next page.
+
+In the same way you can get the previous page with
+
+```java
+Query newQuery = query.previousPage();
+```
+
+If you are already at the "first" page you will get the same Query object.
+
+# QueryBuilder
+
+The QueryBuilder gives you a easy possibility to build any easy or complex
+Queries you need.
+
+
+## creating the filter (where) statement
+
+You can set a String based filter by calling the method 
+
+    queryBuilder.filter(<filter>);
+
+Some examples are:
+
+```java
+String simpleFilter = "userName eq \"marissa\"";
+String filterWithAnd = "addresses.country eq \"Germany\" and active eq \"true\"";
+String filterWithNot = "addresses.country eq \"Germany\" and not(active eq \"true\")";
+String filterForMultiValuedAttribute = "emails sw \"marissa\"";
+String filterForMultiValuedAttributeValue = "emails.value sw \"marissa\"";
+String filterForGroupMembership = "groups.display eq \"group1\"";
+String complexFilter = "active eq \"true\" and(nickname eq \"hello\" or nickname eq \"world\")"
+                + "and not(groups.display eq \"group1\" or groups.display eq \"group2\") "
+                + "and meta.created gt \"" + QueryBuilder.getScimConformFormattedDateTime(dateTime) + "\"";
+```
+
+The following filter options are supported:
+* eq = equals
+* co = contains
+* sw = starts with
+* pr = present
+* gt = greater than
+* ge = greater equals
+* lt = less than
+* le = less equals
+
+Not all filter options are supported with all fields. For example emails.type
+can't be combined with le since it makes no sense.
+
+- all filter parameters have to be surrounded by ". Also boolean parameters or
+numbers
+
+## sorting
+
+OSIAM gives you the opportunity to sort your result by one field. To sort by
+one field call
+
+```java
+queryBuilder.ascending(<sort Field>);
+// or
+queryBuilder.descending(<sort Field>);
+```
+
+## results per page
+
+with
+```java
+queryBuilder.count(20);
+```
+
+you can define how many Users/Groups you want to get for the actual request.
+
+## start index
+with
+ 
+```java
+queryBuilder.startIndex(10);
+```
+
+you can define the 1-based index of the first search result.

--- a/docs/vertx-example.md
+++ b/docs/vertx-example.md
@@ -1,0 +1,79 @@
+This is a simple example how to use the osiam connector4java to retrieve an
+AccessToken using the oauth2 login flow. The sources can be found [here]
+(https://github.com/osiam/examples/tree/master/vertx-3-legged-flow).
+
+```java
+import java.io.IOException;
+import java.net.URI;
+
+import org.osiam.client.connector.OsiamConnector;
+import org.osiam.client.oauth.AccessToken;
+import org.osiam.client.oauth.GrantType;
+import org.osiam.client.oauth.Scope;
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.MultiMap;
+import org.vertx.java.core.Vertx;
+import org.vertx.java.core.VertxFactory;
+import org.vertx.java.core.http.HttpServerRequest;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        Vertx vertx = VertxFactory.newVertx();
+        vertx.createHttpServer().requestHandler(new Handler<HttpServerRequest>() {
+
+            OsiamConnector oConnector;
+
+            {
+                oConnector = new OsiamConnector.Builder()
+                .setEndpoint("http://localhost:8180/osiam-server")
+                .setClientId("example-client")
+                .setClientSecret("secret")
+                .setClientRedirectUri("http://localhost:5000/oauth2")
+                .build();
+            }
+
+            public void handle(HttpServerRequest req) {
+                String path = req.path();
+                if(path.equals("/login")){
+                    URI uri = oConnector.getRedirectLoginUri();
+                    req.response().setStatusCode(301).putHeader("Location", uri.toString()).end();
+                }if(path.equals("/oauth2")){
+                    MultiMap multiMap = req.params();
+                    if(multiMap.get("error") != null){
+                        req.response().setChunked(true).write("The User has denied your request").end();
+                    }else{
+                        //the User has granted your rights to his ressources
+                        String code = multiMap.get("code");
+                        AccessToken accessToken = oConnector.retrieveAccessToken(code, Scope.GET, Scope.PUT, Scope.PATCH);  
+                        req.response().setChunked(true).write("My access token is: " + accessToken.toString()).end();
+                    }
+                }
+                else{
+                     String file = path.equals("/") ? "index.html" : path;
+                     req.response().sendFile("webroot/" + file);    
+                }               
+            }
+        }).listen(5000);
+
+        System.in.read();
+    }
+}   	
+```
+
+The needed simple html page is
+
+```sh
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+		<title>Insert title here</title>
+	</head>
+	<body>
+		Hello, this is a very simple example how to retrieve a OSIAM access Token using the OSIAM oauth2 login flow
+		<br>
+		<a href="/login">login</a>
+	</body>
+</html>
+```

--- a/docs/working-with-groups.md
+++ b/docs/working-with-groups.md
@@ -1,0 +1,145 @@
+To perform any actions with groups you always need an access token. For
+retrieving an access token please see [Login and getting an access token]
+(login-and-getting-an-access-token.md).
+
+The group that will be used by OSIAM and the java connector is
+org.osiam.resources.scim. **Group**.
+Detailed information about can be found in the [scim-schema documentation]
+(https://github.com/osiam/scim-schema/blob/master/docs/README.md).
+
+Chapters:
+- [Group Object](#group)
+- [Creating a Group](#create-a-group)
+- [Deleting a Group](#delete-a-group)
+- [Update a Group](#update-a-group)
+- [Retrieve a single Group](#retrieve-a-single-group)
+- [Retrieve all Groups](#retrieve-all-groups)
+- [Search for groups](#search-for-groups)
+ - [by search string](#search-for-groups-by-search-string)
+ - [by Query](#search-for-groups-by-query)
+      - [braces](#braces)
+
+# Group
+The OSIAM Connector4Java is working with org.osiam.resources.scim. **Group**
+Objects.
+
+A new group can be created with his builder:
+
+```java
+Group group = new Group.Builder(<DisplayName>)
+                //...
+                .build();
+```
+
+Some variables of a group are:
+
+```java
+String displayName = group.getDisplayName();
+Set<MultiValuedAttribute> members = group.getMembers();
+//...
+```
+
+## Create a Group
+
+After you have created a new group you can save it with:
+
+``java
+OsiamConnector oConnector = [Retrieving an OsiamConnector](create-osiam-connector.md)
+
+AccessToken accessToken = [Retrieving an AccessToken](login-and-getting-an-access-token.md#retrieving-an-accesstoken)
+
+Group newGroup = [create a new Group](#group)
+
+newGroup = oConnector.createGroup(newGroup, accessToken);
+```
+
+Now the returned Group Object also contains the ID and meta data of the newly
+created group.
+
+## Delete a Group
+
+To delete a group call:
+
+```java
+OsiamConnector oConnector = [Retrieving an OsiamConnector](create-osiam-connector.md)
+AccessToken accessToken = [Retrieving an AccessToken](login-and-getting-an-access-token.md#retrieving-an-accesstoken)
+oConnector.deleteGroup(<GROUP_UUID>, accessToken);
+```
+
+## Update a Group
+
+The OSIAM connector4Java provides an easy an quick way to change group values or group members.
+It is easy to change data, even if, you want to add one user to all current groups.
+
+The following examples show how you can use the update methods:
+
+```java
+OsiamConnector oConnector = [Retrieving an OsiamConnector](create-osiam-connector.md)
+AccessToken accessToken = [Retrieving an AccessToken](login-and-getting-an-access-token.md#retrieving-an-accesstoken)
+```
+
+If you want to update a group you need to know its ID (UUID). Get the ID with:
+
+    Group existingGroup = [get existing Group](#retrieve-a-single-group)
+
+Now you can create a UpdateGroup and change the attributes:
+
+    UpdateGroup updateGroup = [creating an UpdateGroup](https://github.com/osiam/scim-schema/blob/master/docs/api/update-group.md);
+
+After this you just have to call the UpdateGroup method which will return the
+complete updated group:
+
+    Group updatedGroup = oConnector.updateGroup(existingGroup.getId(), updateGroup, accessToken);
+
+If you want to change the same attributes for several groups you can call the
+method several times with different group ID's and the same UpdateGroup Object:
+
+
+```java
+Group updatedGroup01 = oConnector.updateGroup(groupId01, updateGroup, accessToken);
+Group updatedGroup02 = oConnector.updateGroup(groupId02, updateGroup, accessToken);
+Group updatedGroup03 = oConnector.updateGroup(groupId03, updateGroup, accessToken);
+```
+
+## Retrieve a single Group
+   
+To retrieve a single Group you need her UUID (for example
+94bbe688-4b1e-4e4e-80e7-e5ba5c4d6db4):
+
+```java
+OsiamConnector oConnector = [Retrieving an OsiamConnector](create-osiam-connector.md)
+AccessToken accessToken = [Retrieving an AccessToken](login-and-getting-an-access-token.md#retrieving-an-accesstoken)
+Group group = oConnector.getGroup(<GROUP_UUID>, accessToken);
+```
+(please consider the possible runtimeException which are explained in the
+Javadoc)
+
+## Retrieve all Groups
+
+If you want to retrieve all groups you can call the following method:
+
+```java
+OsiamConnector oConnector = [Retrieving an OsiamConnector](create-osiam-connector.md)
+AccessToken accessToken = [Retrieving an AccessToken](login-and-getting-an-access-token.md#retrieving-an-accesstoken)
+SCIMSearchResult<Group> searchResult = oConnector.getAllGroups(accessToken);
+int numberOfGroups = searchResult.getTotalResults();
+for (Group actGroup : searchResult.Resources()) {
+	//...
+}
+//...
+```
+
+## Search for groups
+
+The [Query](query.md) class helps you
+to create an Query based on the needed filter and other attributes. (The
+examples in the page are for users. Please adapt them for groups)
+
+A complete example how you can run a search for a user is described below:
+
+```java
+OsiamConnector oConnector = [Retrieving an OsiamConnector](create-osiam-connector.md)
+AccessToken accessToken = [Retrieving an AccessToken](login-and-getting-an-access-token.md#retrieving-an-accesstoken)
+Query query = [Create an Query](query.md)
+SCIMSearchResult<Group> result = oConnector.searchGroups(query, accessToken);
+```

--- a/docs/working-with-user.md
+++ b/docs/working-with-user.md
@@ -1,0 +1,166 @@
+To perform any actions with users you always need an access token. For
+retrieving an access token please see [Login and getting an access token](login-and-getting-an-access-token.md).
+
+The user class that will be used by OSIAM and the Java Connector is org.osiam.resources.scim. **User**.
+Detailed information about this class can be found at the [scim-schema]
+(https://github.com/osiam/scim-schema/blob/master/docs/api/user.md).
+
+Chapters:
+- [User Object](#user)
+- [Create a User](#create-a-user)
+- [Delete a User](#delete-a-user)
+- [Update a User](#update-a-user)
+- [Retrieve a single User](#retrieve-a-single-user)
+- [Retrieve the currently logged in User by his access token](#retrieve-the-current-logged-in-user-by-his-access-token)
+- [Retrieve all User](#retrieve-all-users)
+- [Search for Users](#search-for-user)
+
+# User
+
+The OSIAM Connector4Java is working with org.osiam.resources.scim. **User**
+Objects.
+
+A new user can be created with his builder.
+
+```java
+User user = new User.Builder("<userName>")
+                       .setPassword("<password>")
+                       //...
+                       .build();
+```
+
+Some variables of a user are:
+
+```java
+String userName = user.getUserName();
+String userId = user.getId(); //UUID
+List<Address> addresses = user.getAddresses();
+List<Email> emails = user.getEmails();
+String password = user.getPassword(); // will always be null
+//...
+```
+
+# Create a User
+
+After you have created a new user you can save him with:
+
+```java
+OsiamConnector oConnector = [Retrieving an OsiamConnector](create-osiam-connector.md)
+AccessToken accessToken = [Retrieving an AccessToken](login-and-getting-an-access-token.md#retrieving-an-accesstoken)
+User newUser = [create a new User](#user)
+newUser = oConnector.createUser(newUser, accessToken);
+```
+
+Now the returned user object contains the ID and meta data of the newly created
+user.
+
+# Delete a User
+
+To delete a user call:
+
+```java
+OsiamConnector oConnector = [Retrieving an OsiamConnector](create-osiam-connector.md)
+AccessToken accessToken = [Retrieving an AccessToken](login-and-getting-an-access-token.md#retrieving-an-accesstoken)
+oConnector.deleteUser(<USER_UUID>, accessToken);
+```
+
+# Update a User
+
+The OSIAM Connector4Java provides an easy and quick way to change user data,
+whether you just want to update a single value or almost all of them.
+It is easy to change data, even if you want to change the address of all your
+employees because your company moved.
+
+The following examples show how you can use the update method:
+
+```java
+OsiamConnector oConnector = [Retrieving an OsiamConnector](create-osiam-connector.md)
+AccessToken accessToken = [Retrieving an AccessToken](login-and-getting-an-access-token.md#retrieving-an-accesstoken)
+```
+
+If you want to update a user you need to know his ID (UUID). Get the ID with:
+
+    User existingUser = [get existing User](#retrieve-a-single-user)
+
+Now you can create a UpdateUser and change his attributes:
+
+    UpdateUser updateUser = [Creating an UpdateUser](https://github.com/osiam/scim-schema/blob/master/docs/api/update-user.md)
+
+After this you just have to call the UpdateUser method which will return the
+complete updated user:
+
+    User updatedUser = oConnector.updateUser(existingUser.getId(), updateUser, accessToken);
+
+If you want to change the same attributes for several users you can call the
+method several times with different user ID's and the same UpdateUser Object.
+
+
+```java
+User updatedUser01 = oConnector.updateUser(userId01, updateUser, accessToken);
+User updatedUser02 = oConnector.updateUser(userId02, updateUser, accessToken);
+User updatedUser03 = oConnector.updateUser(userId03, updateUser, accessToken);
+```
+
+# Retrieve a single User
+   
+To retrieve a single user you need his UUID (for example:
+94bbe688-4b1e-4e4e-80e7-e5ba5c4d6db4):
+
+```java
+OsiamConnector oConnector = [Retrieving an OsiamConnector](create-osiam-connector.md)
+AccessToken accessToken = [Retrieving an AccessToken](login-and-getting-an-access-token.md#retrieving-an-accesstoken)
+User user = oConnector.getUser(<USER_UUID>, accessToken);
+```
+
+(please consider the possible runtimeException which are explained in the
+Javadoc)
+
+# Retrieve the current logged in user by his access token
+
+If you are logged in with the client scope and you try to retrieve the current
+logged user you will retrieve a ConflictException.
+
+```sh
+OsiamConnector oConnector = [Retrieving an OsiamConnector](create-osiam-connector.md)
+AccessToken accessToken = [Retrieving an AccessToken](login-and-getting-an-access-token.md#retrieving-an-accesstoken)
+// retrieves the basic data of the actual User
+BasicUser basicUser = oConnector.getCurrentUserBasic(accessToken);
+// retrieves the complete currently logged in User.
+User user = oConnector.getCurrentUser(accessToken);
+```
+
+If you only need the basic User data like the userName or the Name, we would
+recommend to use the getCurrentUserBasic method since this one is with more
+performance.
+
+(please consider the possible runtimeException which are explained in the
+Javadoc)
+
+# Retrieve all Users
+
+If you want to retrieve all users you can call the following method:
+
+```java
+OsiamConnector oConnector = [Retrieving an OsiamConnector](create-osiam-connector.md)
+AccessToken accessToken = [Retrieving an AccessToken](login-and-getting-an-access-token.md#retrieving-an-accesstoken)
+SCIMSearchResult<User> searchResult = oConnector.getAllUsers(accessToken);
+int numberOfUsers = searchResult.getTotalResults();
+for (User actUser : searchResult.Resources()) {
+	//...
+}
+//...
+```
+
+# Search for User
+
+The [Query](query.md) class helps you
+to create an Query based on the needed filter and other attributes.
+
+A complete example how you can run a search for a user is described below:
+
+```java
+OsiamConnector oConnector = [Retrieving an OsiamConnector](create-osiam-connector.md)
+AccessToken accessToken = [Retrieving an AccessToken](login-and-getting-an-access-token.md#retrieving-an-accesstoken)
+Query query = [Create an Query](query.md)
+SCIMSearchResult<User> result = oConnector.searchUsers(query, accessToken);
+```

--- a/src/main/java/org/osiam/client/OsiamConnector.java
+++ b/src/main/java/org/osiam/client/OsiamConnector.java
@@ -357,7 +357,7 @@ public class OsiamConnector {
 
     /**
      * Search for existing groups by a given {@link org.osiam.client.query.Query Query}. For more detailed information
-     * about the possible logical operators and usable fields please have a look into the wiki.
+     * about the possible logical operators and usable fields please have a look into the documentation.
      *
      * @param query       containing the needed search where statement
      * @param accessToken the OSIAM access token from for the current session
@@ -366,9 +366,8 @@ public class OsiamConnector {
      * @throws ForbiddenException                if the scope doesn't allow this request
      * @throws ConnectionInitializationException if the connection to the given OSIAM service could not be initialized
      * @throws IllegalStateException             If the resource-server endpoint is not configured
-     * @see <a href="https://github.com/osiam/connector4java/wiki/Working-with-groups#search-for-groups">https://github.
-     * <p/>
-     * com/osiam/connector4java/wiki/Working-with-groups#search-for-groups</a>
+     * @see <a href="https://github.com/osiam/connector4java/docs/working-with-groups
+     * .md#search-for-groups#search-for-groups">Search for groups</a>
      */
     public SCIMSearchResult<Group> searchGroups(Query query, AccessToken accessToken) {
         return groupService().searchGroups(query, accessToken);
@@ -392,14 +391,13 @@ public class OsiamConnector {
 
     /**
      * provides the needed URI which is needed to reconnect the User to the OSIAM server to login. A detailed example
-     * how to use this method, can be seen in our wiki in gitHub
+     * how to use this method, can be seen in the documentation
      *
      * @param scopes the wanted scopes for the user who want's to log in with the oauth workflow
      * @return the needed redirect Uri
      * @throws IllegalStateException If the auth-server endpoint is not configured
-     * @see <a href=
-     * "https://github.com/osiam/connector4java/wiki/Login-and-getting-an-access-token#grant-authorization-code">
-     * https://github.com/osiam/connector4java/wiki/Login-and-getting-an-access-token#grant-authorization-code</a>
+     * @see <a href="https://github.com/osiam/connector4java/docs/login-and-getting-an-access-token
+     * .md#grant-authorization-code">Grant authorization code</a>
      */
     public URI getAuthorizationUri(Scope... scopes) {
         return authService().getAuthorizationUri(scopes);
@@ -435,14 +433,13 @@ public class OsiamConnector {
      * login).
      *
      * @param authCode authentication code retrieved from the OSIAM Server by using the oauth2 login flow. For more
-     *                 information please look at the wiki at github
+     *                 information please check the documentation
      * @return a valid AccessToken
      * @throws ConflictException                 in case the given authCode could not be exchanged against a access token
      * @throws ConnectionInitializationException If the Service is unable to connect to the configured OAuth2 service.
      * @throws IllegalStateException             If the auth-server endpoint is not configured
-     * @see <a href=
-     * "https://github.com/osiam/connector4java/wiki/Login-and-getting-an-access-token#grant-authorization-code">
-     * https://github.com/osiam/connector4java/wiki/Login-and-getting-an-access-token#grant-authorization-code</a>
+     * @see <a href="https://github.com/osiam/connector4java/docs/login-and-getting-an-access-token
+     * .md#grant-authorization-code">Grant authorization code</a>
      */
     public AccessToken retrieveAccessToken(String authCode) {
         return authService().retrieveAccessToken(authCode);
@@ -514,7 +511,7 @@ public class OsiamConnector {
 
     /**
      * update the user of the given id with the values given in the User Object. For more detailed information how to
-     * set new field, update Fields or to delete Fields please look in the wiki
+     * set new field, update Fields or to delete Fields please look in the documentation
      *
      * @param id          if of the User to be updated
      * @param updateUser  all Fields that need to be updated
@@ -526,8 +523,7 @@ public class OsiamConnector {
      * @throws ForbiddenException                if the scope doesn't allow this request
      * @throws ConnectionInitializationException if the connection to the given OSIAM service could not be initialized
      * @throws IllegalStateException             If the resource-server endpoint is not configured
-     * @see <a href="https://github.com/osiam/connector4java/wiki/Working-with-user">https://github.com/osiam/
-     * connector4java/wiki/Working-with-user</a>
+     * @see <a href="https://github.com/osiam/connector4java/docs/working-with-user.md">Working with user</a>
      */
     public User updateUser(String id, UpdateUser updateUser, AccessToken accessToken) {
         return userService().updateUser(id, updateUser, accessToken);
@@ -554,7 +550,7 @@ public class OsiamConnector {
 
     /**
      * update the group of the given id with the values given in the Group Object. For more detailed information how to
-     * set new field. Update Fields or to delete Fields please look in the wiki
+     * set new field. Update Fields or to delete Fields please look in the documentation
      *
      * @param id          id of the Group to be updated
      * @param updateGroup all Fields that need to be updated
@@ -566,8 +562,8 @@ public class OsiamConnector {
      * @throws ForbiddenException                if the scope doesn't allow this request
      * @throws ConnectionInitializationException if the connection to the given OSIAM service could not be initialized
      * @throws IllegalStateException             If the resource-server endpoint is not configured
-     * @see <a href="https://github.com/osiam/connector4java/wiki/Working-with-groups">https://github.com/osiam/
-     * connector4java/wiki/Working-with-groups</a>
+     * @see <a href="https://github.com/osiam/connector4java/docs/working-with-groups
+     * .md#search-for-groups">Working with groups</a>
      */
     public Group updateGroup(String id, UpdateGroup updateGroup, AccessToken accessToken) {
         return groupService().updateGroup(id, updateGroup, accessToken);


### PR DESCRIPTION
Resolves #170 
I cloned the [wiki](https://github.com/osiam/connector4java/wiki) and copied the resolved markdown files to the `docs` folder. I cleaned it up a little bit, but the documentation needs a complete cleanup and/or redesign. I put it under source control as a reminder that the documentation always need to be maintained and in sync with the source code.