### PR TITLE
Revert "Update version to 2.0-SNAPSHOT"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # OSIAM Connector4Java
 
-## Unreleased
+## 1.8 - Unreleased
 
 ### Changes
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>org.osiam</groupId>
     <artifactId>connector4java</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>1.8-SNAPSHOT</version>
 
     <name>OSIAM Connector 4 Java</name>
     <description>Native Java API to connect to the REST based OSIAM services</description>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.osiam</groupId>
             <artifactId>scim-schema</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>1.6-SNAPSHOT</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
It turned out, that maintaining 1.x on a separate branch is the horror. Now
the plan is to support OSIAM < 2.3, >= 2.5 and >= 3.0 on the master branch
with a version of 1.x.