### PR TITLE
Restore support for OSIAM 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## 1.8 - Unreleased
 
-### Changes
+### Features
 
 - Ability to set timeouts on per connector basis
 - Add client management
+- Add legacy schemas mode for connecting to OSIAM <= 2.3
+
+    Please, see [Create an OSIAM connector](docs/create-osiam-connector.md#legacy-schemas),
+    if you use an OSIAM version <= 2.3.
 
 ## 1.7 - 2015-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
     Please, see [Create an OSIAM connector](docs/create-osiam-connector.md#legacy-schemas),
     if you use an OSIAM version <= 2.3.
 
+- Restore support for OSIAM 2.x
+
+### Changes
+
+- `OsiamConnector#setMaxConnections(int maxConnections)` will also set
+  the maximum connections per route to the given value.
+
 ## 1.7 - 2015-09-11
 
 ### Changes

--- a/docs/create-osiam-connector.md
+++ b/docs/create-osiam-connector.md
@@ -2,13 +2,50 @@ To be able to log in, and create or change users or groups you need to create
 an `org.osiam.client.connector.OsiamConnector` instance. You can do this by
 using the `OsiamConnector.Builder()` class.
 
+## OSIAM 3.x
+
+In OSIAM 3.x auth-server and resource-server have been merged to create a better
+user experience. Thus you have to provide only 1 endpoint for the Connector to
+connect to OSIAM:
+
+
 ```java
 OsiamConnector osiamConnector = new OsiamConnector.Builder()
-       .setEndpoint(OSIAM_ENDPOINT)
+       .withEndpoint(OSIAM_ENDPOINT)
        .setClientId(CLIENT_ID)
        .setClientSecret(CLIENT_SECRET)
        .build();
 ```
+
+## OSIAM 2.x
+
+OSIAM consists of 2 servers, namely auth-server and resource-server. Therefore
+you have to provide 2 endpoints for the Connector to connect to OSIAM:
+
+```java
+OsiamConnector osiamConnector = new OsiamConnector.Builder()
+        .setAuthServerEndpoint(AUTH_ENDPOINT_ADDRESS)
+        .setResourceServerEndpoint(RESOURCE_ENDPOINT_ADDRESS)
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .build();
+```
+
+In case your auth and resource server are located at the same location and
+follow the specified naming convention you can also use:
+
+```java
+OsiamConnector osiamConnector = new OsiamConnector.Builder()
+        .setEndpoint(OSIAM_ENDPOINT)
+        .setClientId(CLIENT_ID)
+        .setClientSecret(CLIENT_SECRET)
+        .build();
+```
+
+This will append the default context roots to the given endpoint:
+
+- auth-server: `/osiam-auth-server`
+- resource-server: `/osiam-resource-server`
 
 ## Timeouts
 

--- a/docs/create-osiam-connector.md
+++ b/docs/create-osiam-connector.md
@@ -12,7 +12,8 @@ OsiamConnector osiamConnector = new OsiamConnector.Builder()
 
 ## Timeouts
 
-(since 1.4) You can also set the connect and read timeouts like this:
+Starting with version 1.4 you can also set the connect and read timeouts
+like this:
 
 ```java
 OsiamConnector.setConnectTimeout(2500);
@@ -24,3 +25,20 @@ define them for **all** connectors you create. This will be addressed in a
 future version, but note that it is recommended to use only **one** connector
 instance for the whole application, unless you need to use different OAuth
 clients.
+
+## Legacy Schemas
+
+Starting with version 1.8 you can configure the use of legacy schemas, i.e.
+schemas that were defined before SCIM 2 draft 09, like this:
+
+```java
+OsiamConnector osiamConnector = new OsiamConnector.Builder()
+       ...
+       .withLegacySchemas(true)
+       ...
+       .build();
+```
+
+This enables compatibility with OSIAM releases up to version 2.3 (resource-server 2.2). This
+behavior is not enabled by default. Set it to `true` if you connect to an OSIAM version <= 2.3 and,
+please, update to 2.5 or later immediately.

--- a/docs/login-and-getting-an-access-token.md
+++ b/docs/login-and-getting-an-access-token.md
@@ -26,7 +26,7 @@ With **new Scope("your scope");** you can also create and add your own scopes th
 # Retrieving an access token
 
 In a trusted environment getting an access token from OSIAM implies a successful
-login of the user. 
+login of the user.
 
 ## [Authorization Code Grant](https://github.com/osiam/osiam/blob/master/docs/api_documentation.md#authorization-code-grant)
 
@@ -73,7 +73,7 @@ AccessToken the following way
 
     AccessToken accessToken = new AccessToken.Builder(<token>).build();
 
-## [Resource Owner Password Credentials Grant](https://github.com/osiam/osiam/blob/master/docs/api_documentation.md#resource-owner-password-credentials-grant) 
+## [Resource Owner Password Credentials Grant](https://github.com/osiam/osiam/blob/master/docs/api_documentation.md#resource-owner-password-credentials-grant)
 and
 ## [Client Credentials Grant](https://github.com/osiam/osiam/blob/master/docs/api_documentation.md#client-credentials-grant)
 

--- a/docs/vertx-example.md
+++ b/docs/vertx-example.md
@@ -26,7 +26,10 @@ public class Main {
 
             {
                 oConnector = new OsiamConnector.Builder()
-                .setEndpoint("http://localhost:8180/osiam")
+                // OSIAM 3.x
+                .withEndpoint("http://localhost:8080/osiam")
+                // OSIAM 2.x
+                .setEndpoint("http://localhost:8080")
                 .setClientId("example-client")
                 .setClientSecret("secret")
                 .setClientRedirectUri("http://localhost:5000/oauth2")

--- a/src/main/java/org/osiam/client/OsiamConnector.java
+++ b/src/main/java/org/osiam/client/OsiamConnector.java
@@ -62,6 +62,7 @@ public class OsiamConnector {
 
     static final int DEFAULT_CONNECT_TIMEOUT = 2500;
     static final int DEFAULT_READ_TIMEOUT = 5000;
+    static final boolean DEFAULT_LEGACY_SCHEMAS = false;
     private static final int DEFAULT_MAX_CONNECTIONS = 40;
 
     public static final ObjectMapper objectMapper = new ObjectMapper();
@@ -160,10 +161,12 @@ public class OsiamConnector {
         userService = new OsiamUserService.Builder(endpoint)
                 .withConnectTimeout(builder.connectTimeout)
                 .withReadTimeout(builder.readTimeout)
+                .withLegacySchemas(builder.legacySchemas)
                 .build();
         groupService = new OsiamGroupService.Builder(endpoint)
                 .withConnectTimeout(builder.connectTimeout)
                 .withReadTimeout(builder.readTimeout)
+                .withLegacySchemas(builder.legacySchemas)
                 .build();
     }
 
@@ -623,6 +626,7 @@ public class OsiamConnector {
         private String clientRedirectUri;
         private int connectTimeout = DEFAULT_CONNECT_TIMEOUT;
         private int readTimeout = DEFAULT_READ_TIMEOUT;
+        private boolean legacySchemas = DEFAULT_LEGACY_SCHEMAS;
 
         /**
          * Use the given endpoint for communication with OSIAM
@@ -698,6 +702,22 @@ public class OsiamConnector {
          */
         public Builder withReadTimeout(int readTimeout) {
             this.readTimeout = readTimeout;
+            return this;
+        }
+
+        /**
+         * Configures the connector to use legacy schemas, i.e. schemas that were defined before
+         * SCIM 2 draft 09.
+         *
+         * <p/>This enables compatibility with OSIAM releases up to version 2.3
+         * (resource-server 2.2). This behavior is not enabled by default. Set it to `true` if you
+         * connect to an OSIAM version <= 2.3 and, please, update to 2.5 or later immediately.
+         *
+         * @param legacySchemas should legacy schemas be used
+         * @return The builder itself
+         */
+        public Builder withLegacySchemas(boolean legacySchemas) {
+            this.legacySchemas = legacySchemas;
             return this;
         }
 

--- a/src/main/java/org/osiam/client/OsiamGroupService.java
+++ b/src/main/java/org/osiam/client/OsiamGroupService.java
@@ -38,6 +38,8 @@ import java.util.List;
 class OsiamGroupService extends AbstractOsiamService<Group> { // NOSONAR - Builder constructs instances of
     // this class
 
+    static final String LEGACY_SCHEMA = "urn:scim:schemas:core:2.0:Group";
+
     /**
      * The private constructor for the OsiamGroupService. Please use the {@link OsiamGroupService.Builder} to construct
      * one.
@@ -104,6 +106,16 @@ class OsiamGroupService extends AbstractOsiamService<Group> { // NOSONAR - Build
         return replaceResource(id, group, accessToken);
     }
 
+    @Override
+    protected String getSchema() {
+        return Group.SCHEMA;
+    }
+
+    @Override
+    protected String getLegacySchema() {
+        return LEGACY_SCHEMA;
+    }
+
     /**
      * See {@link OsiamConnector.Builder}
      */
@@ -146,6 +158,22 @@ class OsiamGroupService extends AbstractOsiamService<Group> { // NOSONAR - Build
          */
         public Builder withReadTimeout(int readTimeout) {
             this.readTimeout = readTimeout;
+            return this;
+        }
+
+        /**
+         * Configures the group service to use legacy schemas, i.e. schemas that were defined
+         * before SCIM 2 draft 09.
+         *
+         * <p/>This enables compatibility with OSIAM releases up to version 2.3
+         * (resource-server 2.2). This behavior is not enabled by default. Set it to `true` if you
+         * connect to an OSIAM version <= 2.3 and, please, update to 2.5 or later immediately.
+         *
+         * @param legacySchemas should legacy schemas be used
+         * @return The builder itself
+         */
+        public Builder withLegacySchemas(boolean legacySchemas) {
+            this.legacySchemas = legacySchemas;
             return this;
         }
 

--- a/src/main/java/org/osiam/client/OsiamUserService.java
+++ b/src/main/java/org/osiam/client/OsiamUserService.java
@@ -46,6 +46,8 @@ import java.util.List;
  */
 class OsiamUserService extends AbstractOsiamService<User> {
 
+    static final String LEGACY_SCHEMA = "urn:scim:schemas:core:2.0:User";
+
     /**
      * The private constructor for the OsiamUserService. Please use the {@link OsiamUserService.Builder} to construct
      * one.
@@ -148,6 +150,16 @@ class OsiamUserService extends AbstractOsiamService<User> {
         return replaceResource(id, user, accessToken);
     }
 
+    @Override
+    protected String getSchema() {
+        return User.SCHEMA;
+    }
+
+    @Override
+    protected String getLegacySchema() {
+        return LEGACY_SCHEMA;
+    }
+
     /**
      * See {@link OsiamConnector.Builder}
      */
@@ -190,6 +202,22 @@ class OsiamUserService extends AbstractOsiamService<User> {
          */
         public Builder withReadTimeout(int readTimeout) {
             this.readTimeout = readTimeout;
+            return this;
+        }
+
+        /**
+         * Configures the user service to use legacy schemas, i.e. schemas that were defined before
+         * SCIM 2 draft 09.
+         *
+         * <p/>This enables compatibility with OSIAM releases up to version 2.3
+         * (resource-server 2.2). This behavior is not enabled by default. Set it to `true` if you
+         * connect to an OSIAM version <= 2.3 and, please, update to 2.5 or later immediately.
+         *
+         * @param legacySchemas should legacy schemas be used
+         * @return The builder itself
+         */
+        public Builder withLegacySchemas(boolean legacySchemas) {
+            this.legacySchemas = legacySchemas;
             return this;
         }
 

--- a/src/test/java/org/osiam/client/AuthServiceTest.java
+++ b/src/test/java/org/osiam/client/AuthServiceTest.java
@@ -47,7 +47,8 @@ public class AuthServiceTest {
 
     @Test
     public void service_returns_valid_redirect_Uri() throws Exception {
-        service = new OsiamConnector.Builder().setEndpoint(ENDPOINT)
+        service = new OsiamConnector.Builder()
+                .withEndpoint(ENDPOINT)
                 .setClientId(VALID_CLIENT_ID)
                 .setClientSecret(VALID_CLIENT_SECRET)
                 .setClientRedirectUri(REDIRECT_URI)

--- a/src/test/java/org/osiam/client/OsiamConnectorTest.java
+++ b/src/test/java/org/osiam/client/OsiamConnectorTest.java
@@ -1,0 +1,24 @@
+package org.osiam.client;
+
+import org.junit.Test;
+
+public class OsiamConnectorTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void throws_illegal_state_exception_when_no_resource_server_is_configured_and_user_is_retrieved() {
+        OsiamConnector connector = new OsiamConnector.Builder().setAuthServerEndpoint("irrelevant").build();
+        connector.getUser("irrelevant", null);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void throws_illegal_state_exception_when_no_resource_server_is_configured_and_group_is_retrieved() {
+        OsiamConnector connector = new OsiamConnector.Builder().setAuthServerEndpoint("irrelevant").build();
+        connector.getGroup("irrelevant", null);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void throws_illegal_state_exception_when_no_auth_server_is_configured_and_access_token_is_retrieved() {
+        OsiamConnector connector = new OsiamConnector.Builder().setResourceServerEndpoint("irrelevant").build();
+        connector.retrieveAccessToken("irrelevant");
+    }
+}


### PR DESCRIPTION
We only want to maintain a single version of the connector by now, so old behavior must be restored. This PR contains:

- Bring back the old methods to connect to OSIAM < 3.0
- Integrate these methods into the current way connections are made
- Add a toggle to use legacy schemas of SCIM < 2 draft 09

See the individual commits for more details.

Related PRs: osiam/connector4java-integration-tests#307, osiam/addon-self-administration#159, osiam/examples#26, osiam/addon-administration#112