### PR TITLE
Use coveralls.io for test coverage reporting 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,3 +12,4 @@ test:
     - sudo sh jpmInstall.sh
     - sudo jpm install com.codacy:codacy-coverage-reporter:assembly
     - codacy-coverage-reporter -l Java -r target/coverage-reports/jacoco/jacoco.xml --projectToken $CODACY_PROJECT_TOKEN
+    - mvn coveralls:report -DrepoToken=$COVERALLS_REPO_TOKEN 

--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,17 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>4.1.0</version>
+                <configuration>
+                    <jacocoReports>
+                        <entry>${project.build.directory}/coverage-reports/jacoco/jacoco.xml</entry>
+                    </jacocoReports>
+                </configuration>
+            </plugin>
+
             <!-- Shade all dependencies for compatibility reasons -->
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>


### PR DESCRIPTION
This pull request adds [coveralls.io](https://coveralls.io) support to the project to track test coverage reporting.