### PR TITLE
Don't report coverage when building pull requests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,9 @@
 dependencies:
   override:
     - mvn -U dependency:resolve dependency:resolve-plugins
+    - curl http://www.jpm4j.org/install/script > jpmInstall.sh
+    - sudo sh jpmInstall.sh
+    - sudo jpm install com.codacy:codacy-coverage-reporter:assembly
 test:
   override:
     - mvn verify
@@ -8,8 +11,5 @@ test:
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/
     - find . -type f -regex ".*/target/.*-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
     - cp -r target/coverage-reports/jacoco/ $CIRCLE_ARTIFACTS
-    - curl http://www.jpm4j.org/install/script > jpmInstall.sh
-    - sudo sh jpmInstall.sh
-    - sudo jpm install com.codacy:codacy-coverage-reporter:assembly
-    - codacy-coverage-reporter -l Java -r target/coverage-reports/jacoco/jacoco.xml --projectToken $CODACY_PROJECT_TOKEN
-    - mvn coveralls:report -DrepoToken=$COVERALLS_REPO_TOKEN 
+    - test -z $CODACY_PROJECT_TOKEN || codacy-coverage-reporter -l Java -r target/coverage-reports/jacoco/jacoco.xml --projectToken $CODACY_PROJECT_TOKEN
+    - test -z $COVERALLS_REPO_TOKEN || mvn coveralls:report -DrepoToken=$COVERALLS_REPO_TOKEN


### PR DESCRIPTION
Circleci hides 'secure' environment variables from pull request builds, and rightly so. However this did fail our pull request builds because we need access to the api token of coveralls.io this pull request doesn't report the coverage data if the token is not available.