### PR TITLE
Handle a 400 BAD REQUEST correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # OSIAM Connector4Java
 
+## Unreleased
+
+### Fixes
+
+- A `400 BAD REQUEST` response creates a `BadRequestException` instead of the appropriate `ConflictException` 
+
 ## 1.8 - 2015-12-12
 
 ### Features

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <sonar.core.codeCoveragePlugin>cobertura</sonar.core.codeCoveragePlugin>
         <!-- force sonar to reuse reports generated during build cycle -->
         <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
+        <mockserver.version>3.10.2</mockserver.version>
     </properties>
 
     <dependencies>
@@ -121,6 +122,24 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
             <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-netty</artifactId>
+            <version>${mockserver.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-core</artifactId>
+            <version>${mockserver.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-client-java</artifactId>
+            <version>${mockserver.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/org/osiam/client/AbstractOsiamService.java
+++ b/src/main/java/org/osiam/client/AbstractOsiamService.java
@@ -67,14 +67,12 @@ abstract class AbstractOsiamService<T extends Resource> {
 
     protected static final String AUTHORIZATION = "Authorization";
     protected static final String BEARER = "Bearer ";
-
+    protected final WebTarget targetEndpoint;
     private final Class<T> type;
     private final String typeName;
     private final int connectTimeout;
     private final int readTimeout;
     private final boolean legacySchemas;
-
-    protected final WebTarget targetEndpoint;
 
     protected AbstractOsiamService(Builder<T> builder) {
         type = builder.type;
@@ -90,6 +88,10 @@ abstract class AbstractOsiamService<T extends Resource> {
         objectMapper.registerModule(userDeserializerModule);
 
         targetEndpoint = OsiamConnector.getClient().target(builder.endpoint);
+    }
+
+    protected static void checkAccessTokenIsNotNull(AccessToken accessToken) {
+        checkNotNull(accessToken, "The given accessToken must not be null.");
     }
 
     protected T getResource(String id, AccessToken accessToken) {
@@ -305,7 +307,7 @@ abstract class AbstractOsiamService<T extends Resource> {
             throw new UnauthorizedException(errorMessage);
         } else if (status.getStatusCode() == Status.BAD_REQUEST.getStatusCode()) {
             String errorMessage = extractErrorMessage(content, status);
-            throw new ConflictException(errorMessage);
+            throw new BadRequestException(errorMessage);
         } else if (status.getStatusCode() == Status.NOT_FOUND.getStatusCode()) {
             String errorMessage = extractErrorMessage(content, status);
             throw new NoResultException(errorMessage);
@@ -385,10 +387,6 @@ abstract class AbstractOsiamService<T extends Resource> {
         }
     }
 
-    protected static void checkAccessTokenIsNotNull(AccessToken accessToken) {
-        checkNotNull(accessToken, "The given accessToken must not be null.");
-    }
-
     protected int getConnectTimeout() {
         return connectTimeout;
     }
@@ -399,12 +397,12 @@ abstract class AbstractOsiamService<T extends Resource> {
 
     protected static class Builder<T> {
 
-        private String endpoint;
-        private Class<T> type;
-        private String typeName;
         protected int connectTimeout = OsiamConnector.DEFAULT_CONNECT_TIMEOUT;
         protected int readTimeout = OsiamConnector.DEFAULT_READ_TIMEOUT;
         protected boolean legacySchemas = OsiamConnector.DEFAULT_LEGACY_SCHEMAS;
+        private String endpoint;
+        private Class<T> type;
+        private String typeName;
 
         @SuppressWarnings("unchecked")
         protected Builder(String endpoint) {


### PR DESCRIPTION
Fix a bug that turned a 400 BAD REQUEST response code into a
ConflictException instead of the appropriate BadRequestException.

This pull introduces (MockServer)[http://www.mock-server.com]
as a utility to write more and better tests.