### PR TITLE
Make /Me resource to be scim compliant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Changes
+
+- Introduce a `getMe()` method to retrieve the currently logged in user
+  from OSIAM 3.0
+- The `BasicUser` class and the method `getCurrentUserBasic()` have been deprecated.
+
 ### Fixes
 
 - A `400 BAD REQUEST` response creates a `BadRequestException` instead of the appropriate `ConflictException` 

--- a/src/main/java/org/osiam/client/user/BasicUser.java
+++ b/src/main/java/org/osiam/client/user/BasicUser.java
@@ -23,21 +23,22 @@
  */
 package org.osiam.client.user;
 
-import java.util.Date;
-
-import org.osiam.resources.helper.JsonDateSerializer;
-import org.osiam.resources.scim.User;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.osiam.resources.helper.JsonDateSerializer;
+import org.osiam.resources.scim.User;
+
+import java.util.Date;
 
 /**
  * represents the basic Data of a scim User
+ * @deprecated This class has been deprecated with OSIAM 3.0
  *
  */
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
-@JsonIgnoreProperties({ "link", "gender", "timezone", "verified" })
+@JsonIgnoreProperties({"link", "gender", "timezone", "verified"})
+@Deprecated
 public class BasicUser {
 
     private String id;

--- a/src/main/java/org/osiam/resources/scim/User.java
+++ b/src/main/java/org/osiam/resources/scim/User.java
@@ -75,30 +75,30 @@ public final class User extends Resource implements Serializable {
 
     @JsonCreator
     private User(@JsonProperty("id") String id,
-                @JsonProperty("externalId") String externalId,
-                @JsonProperty("meta") Meta meta,
-                @JsonProperty(value = "schemas", required = true) Set<String> schemas,
-                @JsonProperty("userName") String userName,
-                @JsonProperty("name") Name name,
-                @JsonProperty("displayName") String displayName,
-                @JsonProperty("nickName") String nickName,
-                @JsonProperty("profileUrl") String profileUrl,
-                @JsonProperty("title") String title,
-                @JsonProperty("userType") String userType,
-                @JsonProperty("preferredLanguage") String preferredLanguage,
-                @JsonProperty("locale") String locale,
-                @JsonProperty("timezone") String timezone,
-                @JsonProperty("active") Boolean active,
-                @JsonProperty("emails") List<Email> emails,
-                @JsonProperty("phoneNumbers") List<PhoneNumber> phoneNumbers,
-                @JsonProperty("ims") List<Im> ims,
-                @JsonProperty("photos") List<Photo> photos,
-                @JsonProperty("addresses") List<Address> addresses,
-                @JsonProperty("groups") List<GroupRef> groups,
-                @JsonProperty("entitlements") List<Entitlement> entitlements,
-                @JsonProperty("roles") List<Role> roles,
-                @JsonProperty("x509Certificates") List<X509Certificate> x509Certificates,
-                @JsonProperty("extensions") Map<String, Extension> extensions) {
+                 @JsonProperty("externalId") String externalId,
+                 @JsonProperty("meta") Meta meta,
+                 @JsonProperty(value = "schemas", required = true) Set<String> schemas,
+                 @JsonProperty("userName") String userName,
+                 @JsonProperty("name") Name name,
+                 @JsonProperty("displayName") String displayName,
+                 @JsonProperty("nickName") String nickName,
+                 @JsonProperty("profileUrl") String profileUrl,
+                 @JsonProperty("title") String title,
+                 @JsonProperty("userType") String userType,
+                 @JsonProperty("preferredLanguage") String preferredLanguage,
+                 @JsonProperty("locale") String locale,
+                 @JsonProperty("timezone") String timezone,
+                 @JsonProperty("active") Boolean active,
+                 @JsonProperty("emails") List<Email> emails,
+                 @JsonProperty("phoneNumbers") List<PhoneNumber> phoneNumbers,
+                 @JsonProperty("ims") List<Im> ims,
+                 @JsonProperty("photos") List<Photo> photos,
+                 @JsonProperty("addresses") List<Address> addresses,
+                 @JsonProperty("groups") List<GroupRef> groups,
+                 @JsonProperty("entitlements") List<Entitlement> entitlements,
+                 @JsonProperty("roles") List<Role> roles,
+                 @JsonProperty("x509Certificates") List<X509Certificate> x509Certificates,
+                 @JsonProperty("extensions") Map<String, Extension> extensions) {
         super(id, externalId, meta, schemas);
         this.userName = (userName != null ? userName : "");
         this.name = name;
@@ -506,6 +506,9 @@ public final class User extends Resource implements Serializable {
                 + getExternalId() + ", getMeta()=" + getMeta() + ", getSchemas()=" + getSchemas() + "]";
     }
 
+    public static Builder Builder(){
+        return new Builder();
+    }
     /**
      * Builder class that is used to build {@link User} instances
      */
@@ -951,7 +954,7 @@ public final class User extends Resource implements Serializable {
         }
 
         /**
-         * removes all Addresses from the actual User
+         * removes all Addresses from the current User
          *
          * @return the builder itself
          */

--- a/src/test/java/org/osiam/client/OsiamUserServiceTest.java
+++ b/src/test/java/org/osiam/client/OsiamUserServiceTest.java
@@ -23,6 +23,7 @@
  */
 package org.osiam.client;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -98,10 +99,24 @@ public class OsiamUserServiceTest {
                                 .withMethod("GET")
                                 .withPath("/osiam/Users")
                                 .withQueryStringParameter("filter", filter),
-                        Times.exactly(1))
+                        Times.once())
                 .respond(response().withStatusCode(Response.Status.BAD_REQUEST.getStatusCode()));
 
         service.searchUsers(new QueryBuilder().filter(filter).build(), accessToken);
+    }
+
+    public void request_of_me_resource_is_build_correctly() throws Exception {
+        User resultingUser = new User.Builder("Name").setId(USER_ID).build();
+        ObjectMapper mapper = new ObjectMapper();
+        mockServerClient
+                .when(
+                        request()
+                                .withMethod("GET")
+                                .withPath("/osiam/Me")
+                                .withHeader("Authorization", "Bearer " + accessToken),
+                        Times.once())
+                .respond(response().withBody(mapper.writeValueAsString(resultingUser)));
+        service.getMe(accessToken);
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Since OSIAM made changes to make the `/Me` resource more SCIM compliant,
this change adjusts the connector accordingly: It adds a new `getMe()`
method that uses the revamped resource and  marks the `BasicUser`
class and the `getCurrentUserBasic()` method as deprecated. It requires the corresponding pull request osiam/osiam#185 to be merged to work.