### PR TITLE
Ignore extensions in schemas without any data present

### DIFF
--- a/src/main/java/org/osiam/resources/helper/UserDeserializer.java
+++ b/src/main/java/org/osiam/resources/helper/UserDeserializer.java
@@ -26,7 +26,11 @@ package org.osiam.resources.helper;
 import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import org.osiam.resources.scim.Extension;
@@ -96,12 +100,13 @@ public class UserDeserializer extends StdDeserializer<User> {
 
             JsonNode extensionNode = rootNode.get(urn);
             if (extensionNode == null) {
-                throw new JsonParseException("Registered extension not present: " + urn, JsonLocation.NA);
+                continue;
             }
 
             builder.addExtension(deserializeExtension(extensionNode, urn));
 
         }
+
         return builder.build();
     }
 

--- a/src/test/groovy/org/osiam/test/util/JsonFixturesHelper.groovy
+++ b/src/test/groovy/org/osiam/test/util/JsonFixturesHelper.groovy
@@ -23,15 +23,12 @@
  */
 package org.osiam.test.util
 
-import groovy.text.SimpleTemplateEngine
-import groovy.text.Template
-
-import org.osiam.resources.helper.UserDeserializer
-import org.osiam.resources.scim.User
-
 import com.fasterxml.jackson.core.Version
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
+import groovy.text.SimpleTemplateEngine
+import org.osiam.resources.helper.UserDeserializer
+import org.osiam.resources.scim.User
 
 class JsonFixturesHelper {
 
@@ -49,7 +46,6 @@ class JsonFixturesHelper {
     def jsonSimpleUser = template.make([schemasMore:'', dataMore:'']).toString()
     def jsonBasicUser = template.make([schemasMore:'', dataMore:tplJsonPartialCollections]).toString()
     def jsonExtendedUser = template.make([schemasMore:tplJsonPartialEnterpriseUrn, dataMore:tplJsonPartialCollections + tplJsonPartialExtension]).toString()
-    def jsonExtendedUserWithoutExtensionData = template.make([schemasMore:tplJsonPartialEnterpriseUrn, dataMore:tplJsonPartialCollections]).toString()
     def jsonExtendedUserWithWrongFieldType = template.make([schemasMore:tplJsonPartialEnterpriseUrn, dataMore:tplJsonPartialCollections + tplJsonPartialWrongTypeExtension]).toString()
 
     public ObjectMapper configuredObjectMapper() {


### PR DESCRIPTION
The SCIM spec states [1]:

> Each value in the "schemas" attribute indicates additive schema that
> MAY exist in a SCIM resource representation.

Hence, missing data should just be ignored instead of throwing an
exception.

Also, refactor the test in `UserDeserializerSpec` to eventually get rid
of the `JsonFixturesHelper` sometimes.

[1] https://tools.ietf.org/html/rfc7643#section-3.3

Fixes #197