### PR TITLE
Extend SCIM address by display name to be SCIM conform

### DIFF
--- a/src/main/java/org/osiam/resources/scim/Address.java
+++ b/src/main/java/org/osiam/resources/scim/Address.java
@@ -168,6 +168,11 @@ public final class Address extends MultiValuedAttribute implements Serializable 
     }
 
     @Override
+    public String getDisplay() {
+        return super.getDisplay();
+    }
+
+    @Override
     public int hashCode() {
         final int prime = 31;
         int result = super.hashCode();
@@ -370,6 +375,12 @@ public final class Address extends MultiValuedAttribute implements Serializable 
         @Override
         public Builder setOperation(String operation) {
             super.setOperation(operation);
+            return this;
+        }
+
+        @Override
+        public Builder setDisplay(String display) {
+            super.setDisplay(display);
             return this;
         }
 

--- a/src/test/groovy/org/osiam/resources/scim/UserJsonSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/scim/UserJsonSpec.groovy
@@ -56,19 +56,23 @@ class UserJsonSpec extends Specification {
                 .setLocale('de')
                 .addEmail(new Email.Builder()
                         .setValue('bjensen@example.com')
-                        .setType(Email.Type.WORK).build())
+                        .setType(Email.Type.WORK)
+                        .setDisplay('mymail').build())
                 .addPhoto(new Photo.Builder()
-                        .setValue('example.png').build())
+                        .setValue('example.png')
+                        .setDisplay('myphoto').build())
                 .addPhoneNumber(new PhoneNumber.Builder()
                         .setValue('555-555-8377')
-                        .setType(PhoneNumber.Type.WORK).build())
+                        .setType(PhoneNumber.Type.WORK)
+                        .setDisplay('myphonenumber').build())
                 .addAddress(new Address.Builder()
                         .setType(Address.Type.WORK)
                         .setStreetAddress('example street 42')
                         .setLocality('Bonn')
                         .setRegion('North Rhine-Westphalia')
                         .setPostalCode('11111')
-                        .setCountry('Germany').build())
+                        .setCountry('Germany')
+                        .setDisplay('myaddress').build())
                 .addExtension(new Extension.Builder('urn:scim:schemas:extension:test:1.0:User')
                         .setField('keyString', 'example')
                         .setField('keyBoolean', true)
@@ -99,15 +103,19 @@ class UserJsonSpec extends Specification {
         json.getString('locale') == 'de'
         json.getString('emails[0].value') == 'bjensen@example.com'
         json.getString('emails[0].type') == 'work'
+        json.getString('emails[0].display') == 'mymail'
         json.getString('photos[0].value') == 'example.png'
+        json.getString('photos[0].display') == 'myphoto'
         json.getString('phoneNumbers[0].value') == '555-555-8377'
         json.getString('phoneNumbers[0].type') == 'work'
+        json.getString('phoneNumbers[0].display') == 'myphonenumber'
         json.getString('addresses[0].type') == 'work'
         json.getString('addresses[0].streetAddress') == 'example street 42'
         json.getString('addresses[0].locality') == 'Bonn'
         json.getString('addresses[0].region') == 'North Rhine-Westphalia'
         json.getString('addresses[0].postalCode') == '11111'
         json.getString('addresses[0].country') == 'Germany'
+        json.getString('addresses[0].display') == 'myaddress'
         json.getString('\'urn:scim:schemas:extension:test:1.0:User\'.keyString') == 'example'
         json.getBoolean('\'urn:scim:schemas:extension:test:1.0:User\'.keyBoolean') == true
         json.getInt('\'urn:scim:schemas:extension:test:1.0:User\'.keyInteger') == 123

--- a/src/test/groovy/org/osiam/resources/scim/UserSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/scim/UserSpec.groovy
@@ -84,7 +84,7 @@ class UserSpec extends Specification {
         PhoneNumber phoneNumber = getPhoneNumber()
         Photo photo = getPhoto()
         Role role = getRole()
-        X509Certificate x509Certificat = getX509Certificat()
+        X509Certificate x509Certificate = getX509Certificate()
 
         def builder = new User.Builder('username')
                 .setId('id')
@@ -106,7 +106,7 @@ class UserSpec extends Specification {
                 .addRoles([role] as List)
                 .setTimezone('MEZ')
                 .setTitle('title')
-                .addX509Certificates([x509Certificat] as List)
+                .addX509Certificates([x509Certificate] as List)
                 .setMeta(meta)
                 .setUserType('userType')
                 .addExtension(extension)
@@ -133,7 +133,7 @@ class UserSpec extends Specification {
         user.timezone == 'MEZ'
         user.title == 'title'
         user.userType == 'userType'
-        user.x509Certificates.first() == x509Certificat
+        user.x509Certificates.first() == x509Certificate
         user.userName == 'username'
         user.id == 'id'
         user.meta == meta
@@ -347,6 +347,7 @@ class UserSpec extends Specification {
                 .setPrimary(true)
                 .setValue('test@tarent.de')
                 .setType(Email.Type.WORK)
+                .setDisplay('mymail')
                 .build()
     }
 
@@ -360,13 +361,14 @@ class UserSpec extends Specification {
                 .setRegion('Berlin')
                 .setStreetAddress('Voltastr. 5')
                 .setType(Address.Type.WORK)
+                .setDisplay('myaddress')
                 .build()
     }
 
     Extension getExtension(urn) {
-        Extension extension = new Extension.Builder(urn)
-                .setField('gender', 'male').build()
-        return extension
+        new Extension.Builder(urn)
+                .setField('gender', 'male')
+                .build()
     }
 
     Entitlement getEntitlement() {
@@ -374,6 +376,7 @@ class UserSpec extends Specification {
                 .setPrimary(true)
                 .setType(new Entitlement.Type('irrelevant'))
                 .setValue('entitlement')
+                .setDisplay('myentitlement')
                 .build()
     }
 
@@ -382,6 +385,7 @@ class UserSpec extends Specification {
                 .setPrimary(true)
                 .setType(Im.Type.AIM)
                 .setValue('aim')
+                .setDisplay('aim')
                 .build()
     }
 
@@ -392,7 +396,8 @@ class UserSpec extends Specification {
                 .setGivenName('test')
                 .setHonorificPrefix('Dr.')
                 .setHonorificSuffix('Mr.')
-                .setMiddleName('test').build()
+                .setMiddleName('test')
+                .build()
     }
 
     PhoneNumber getPhoneNumber() {
@@ -400,6 +405,7 @@ class UserSpec extends Specification {
                 .setPrimary(true)
                 .setType(PhoneNumber.Type.WORK)
                 .setValue('03012345678')
+                .setDisplay('myphonenumber')
                 .build()
     }
 
@@ -408,6 +414,7 @@ class UserSpec extends Specification {
                 .setPrimary(true)
                 .setType(Photo.Type.PHOTO)
                 .setValue('username.jpg')
+                .setDisplay('myphoto')
                 .build()
     }
 
@@ -415,13 +422,15 @@ class UserSpec extends Specification {
         new Role.Builder()
                 .setPrimary(true)
                 .setValue('user_role')
+                .setDisplay('myrole')
                 .build()
     }
 
-    X509Certificate getX509Certificat() {
+    X509Certificate getX509Certificate() {
         new X509Certificate.Builder()
                 .setPrimary(true)
-                .setValue('x509Certificat')
+                .setValue('x509Certificate')
+                .setDisplay('mycert')
                 .build()
     }
 
@@ -444,7 +453,8 @@ class UserSpec extends Specification {
                 .setLocale('de')
                 .addEmail(new Email.Builder()
                 .setValue('bjensen@example.com')
-                .setType(Email.Type.WORK).build())
+                .setType(Email.Type.WORK)
+                .setDisplay('myemail').build())
                 .addPhoto(new Photo.Builder()
                 .setValue('example.png').build())
                 .addPhoneNumber(new PhoneNumber.Builder()
@@ -456,7 +466,8 @@ class UserSpec extends Specification {
                 .setLocality('Bonn')
                 .setRegion('North Rhine-Westphalia')
                 .setPostalCode('11111')
-                .setCountry('Germany').build())
+                .setCountry('Germany')
+                .setDisplay('myaddress').build())
                 .addExtension(new Extension.Builder('urn:scim:schemas:extension:test:1.0:User')
                 .setField('keyString', 'example')
                 .setField('keyBoolean', true)


### PR DESCRIPTION
Any SCIM multi-valued attribute must have a display name:
https://tools.ietf.org/html/rfc7643#section-2.4

Also include display name of multi-valued attributes
in unit tests.