### PR TITLE
Fix broken immutability of resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+- Resources could be changed by using the copy-of constructor of the builders, though they are immutable.
 - A `400 BAD REQUEST` response now creates a `BadRequestException` instead of a `ConflictException` 
 
 ## 1.8 - 2015-12-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixes
 
-- A `400 BAD REQUEST` response creates a `BadRequestException` instead of the appropriate `ConflictException` 
+- A `400 BAD REQUEST` response now creates a `BadRequestException` instead of a `ConflictException` 
 
 ## 1.8 - 2015-12-12
 

--- a/src/main/java/org/osiam/resources/scim/Group.java
+++ b/src/main/java/org/osiam/resources/scim/Group.java
@@ -32,7 +32,6 @@ import com.google.common.collect.ImmutableSet;
 import org.osiam.resources.exception.SCIMDataValidationException;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -61,7 +60,7 @@ public final class Group extends Resource implements Serializable {
                   @JsonProperty("members") Set<MemberRef> members) {
         super(id, externalId, meta, schemas);
         this.displayName = displayName;
-        this.members = (members != null ? members : Collections.<MemberRef>emptySet());
+        this.members = members != null ? ImmutableSet.copyOf(members) : ImmutableSet.<MemberRef>of();
     }
 
     Group(Builder builder) {
@@ -90,7 +89,7 @@ public final class Group extends Resource implements Serializable {
      * @return the list of Members as a Set
      */
     public Set<MemberRef> getMembers() {
-        return ImmutableSet.copyOf(members);
+        return members;
     }
 
     @Override
@@ -120,7 +119,7 @@ public final class Group extends Resource implements Serializable {
             addSchema(SCHEMA);
             if (group != null) {
                 this.displayName = group.displayName;
-                members = group.members;
+                members.addAll(group.members);
             }
             if (!Strings.isNullOrEmpty(displayName)) {
                 this.displayName = displayName;

--- a/src/main/java/org/osiam/resources/scim/Group.java
+++ b/src/main/java/org/osiam/resources/scim/Group.java
@@ -64,10 +64,9 @@ public final class Group extends Resource implements Serializable {
         this.members = (members != null ? members : Collections.<MemberRef>emptySet());
     }
 
-    private Group(Builder builder) {
-        super(builder);
-        this.displayName = builder.displayName;
-        this.members = builder.members;
+    Group(Builder builder) {
+        this(builder.getId(), builder.getExternalId(), builder.getMeta(), builder.getSchemas(),
+                builder.displayName, builder.members);
     }
 
     /**

--- a/src/main/java/org/osiam/resources/scim/Resource.java
+++ b/src/main/java/org/osiam/resources/scim/Resource.java
@@ -49,7 +49,7 @@ public abstract class Resource implements Serializable {
         if (schemas == null || schemas.isEmpty()) {
             throw new SCIMDataValidationException("Schemas cannot be null or empty!");
         }
-        this.schemas = schemas;
+        this.schemas = ImmutableSet.copyOf(schemas);
     }
 
     /**
@@ -90,7 +90,7 @@ public abstract class Resource implements Serializable {
      * @return a the list of schemas as a {@link Set}
      */
     public Set<String> getSchemas() {
-        return ImmutableSet.copyOf(schemas);
+        return schemas;
     }
 
     @Override
@@ -138,7 +138,7 @@ public abstract class Resource implements Serializable {
                 this.id = resource.id;
                 this.externalId = resource.externalId;
                 this.meta = resource.meta;
-                this.schemas = resource.schemas;
+                this.schemas.addAll(resource.schemas);
             }
         }
 

--- a/src/main/java/org/osiam/resources/scim/Resource.java
+++ b/src/main/java/org/osiam/resources/scim/Resource.java
@@ -42,7 +42,7 @@ public abstract class Resource implements Serializable {
     private final Meta meta;
     private final Set<String> schemas;
 
-    protected Resource(String id, String externalId, Meta meta, Set<String> schemas) {
+    Resource(String id, String externalId, Meta meta, Set<String> schemas) {
         this.id = id;
         this.externalId = externalId;
         this.meta = meta;
@@ -50,13 +50,6 @@ public abstract class Resource implements Serializable {
             throw new SCIMDataValidationException("Schemas cannot be null or empty!");
         }
         this.schemas = schemas;
-    }
-
-    protected Resource(Builder builder) {
-        this.id = builder.id;
-        this.externalId = builder.externalId;
-        this.meta = builder.meta;
-        this.schemas = builder.schemas;
     }
 
     /**
@@ -134,7 +127,8 @@ public abstract class Resource implements Serializable {
      * The Builder class is used to construct instances of the {@link Resource}
      */
     public abstract static class Builder {
-        protected String externalId;
+
+        private String externalId;
         private String id;
         private Meta meta;
         private Set<String> schemas = new HashSet<>();
@@ -207,6 +201,22 @@ public abstract class Resource implements Serializable {
         public Builder setMeta(Meta meta) {
             this.meta = meta;
             return this;
+        }
+
+        protected String getExternalId() {
+            return externalId;
+        }
+
+        protected String getId() {
+            return id;
+        }
+
+        protected Meta getMeta() {
+            return meta;
+        }
+
+        protected Set<String> getSchemas() {
+            return schemas;
         }
 
         /**

--- a/src/main/java/org/osiam/resources/scim/Resource.java
+++ b/src/main/java/org/osiam/resources/scim/Resource.java
@@ -23,7 +23,6 @@
  */
 package org.osiam.resources.scim;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSet;
 import org.osiam.resources.exception.SCIMDataValidationException;
 
@@ -41,13 +40,9 @@ public abstract class Resource implements Serializable {
     private final String id;
     private final String externalId;
     private final Meta meta;
-    @JsonProperty(required = true)
     private final Set<String> schemas;
 
-    protected Resource(@JsonProperty("id") String id,
-                       @JsonProperty("externalId") String externalId,
-                       @JsonProperty("meta") Meta meta,
-                       @JsonProperty(value = "schemas", required = true) Set<String> schemas) {
+    protected Resource(String id, String externalId, Meta meta, Set<String> schemas) {
         this.id = id;
         this.externalId = externalId;
         this.meta = meta;

--- a/src/main/java/org/osiam/resources/scim/User.java
+++ b/src/main/java/org/osiam/resources/scim/User.java
@@ -98,6 +98,7 @@ public final class User extends Resource implements Serializable {
                  @JsonProperty("locale") String locale,
                  @JsonProperty("timezone") String timezone,
                  @JsonProperty("active") Boolean active,
+                 @JsonProperty("password") String password,
                  @JsonProperty("emails") List<Email> emails,
                  @JsonProperty("phoneNumbers") List<PhoneNumber> phoneNumbers,
                  @JsonProperty("ims") List<Im> ims,
@@ -120,7 +121,7 @@ public final class User extends Resource implements Serializable {
         this.locale = locale;
         this.timezone = timezone;
         this.active = active;
-        this.password = "";
+        this.password = password != null ? password : "";
         this.emails = (emails != null ? emails : new ArrayList<Email>());
         this.phoneNumbers = (phoneNumbers != null ? phoneNumbers : new ArrayList<PhoneNumber>());
         this.ims = (ims != null ? ims : new ArrayList<Im>());
@@ -133,31 +134,13 @@ public final class User extends Resource implements Serializable {
         this.extensions = (extensions != null ? extensions : new HashMap<String, Extension>());
     }
 
-    private User(Builder builder) {
-        super(builder);
-        this.userName = builder.userName;
-        this.name = builder.name;
-        this.displayName = builder.displayName;
-        this.nickName = builder.nickName;
-        this.profileUrl = builder.profileUrl;
-        this.title = builder.title;
-        this.userType = builder.userType;
-        this.preferredLanguage = builder.preferredLanguage;
-        this.locale = builder.locale;
-        this.timezone = builder.timezone;
-        this.active = builder.active;
-        this.password = builder.password;
-
-        this.emails = builder.emails;
-        this.phoneNumbers = builder.phoneNumbers;
-        this.ims = builder.ims;
-        this.photos = builder.photos;
-        this.addresses = builder.addresses;
-        this.groups = builder.groups;
-        this.entitlements = builder.entitlements;
-        this.roles = builder.roles;
-        this.x509Certificates = builder.x509Certificates;
-        this.extensions = builder.extensions;
+    User(Builder builder) {
+        this(builder.getId(), builder.getExternalId(), builder.getMeta(), builder.getSchemas(),
+                builder.userName, builder.name, builder.displayName, builder.nickName, builder.profileUrl,
+                builder.title, builder.userType, builder.preferredLanguage, builder.locale, builder.timezone,
+                builder.active, builder.password, builder.emails, builder.phoneNumbers, builder.ims,
+                builder.photos, builder.addresses, builder.groups, builder.entitlements, builder.roles,
+                builder.x509Certificates, builder.extensions);
     }
 
     /**

--- a/src/main/java/org/osiam/resources/scim/User.java
+++ b/src/main/java/org/osiam/resources/scim/User.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -110,7 +109,7 @@ public final class User extends Resource implements Serializable {
                  @JsonProperty("x509Certificates") List<X509Certificate> x509Certificates,
                  @JsonProperty("extensions") Map<String, Extension> extensions) {
         super(id, externalId, meta, schemas);
-        this.userName = (userName != null ? userName : "");
+        this.userName = userName != null ? userName : "";
         this.name = name;
         this.displayName = displayName;
         this.nickName = nickName;
@@ -122,16 +121,18 @@ public final class User extends Resource implements Serializable {
         this.timezone = timezone;
         this.active = active;
         this.password = password != null ? password : "";
-        this.emails = (emails != null ? emails : new ArrayList<Email>());
-        this.phoneNumbers = (phoneNumbers != null ? phoneNumbers : new ArrayList<PhoneNumber>());
-        this.ims = (ims != null ? ims : new ArrayList<Im>());
-        this.photos = (photos != null ? photos : new ArrayList<Photo>());
-        this.addresses = (addresses != null ? addresses : new ArrayList<Address>());
-        this.groups = (groups != null ? groups : new ArrayList<GroupRef>());
-        this.entitlements = (entitlements != null ? entitlements : new ArrayList<Entitlement>());
-        this.roles = (roles != null ? roles : new ArrayList<Role>());
-        this.x509Certificates = (x509Certificates != null ? x509Certificates : new ArrayList<X509Certificate>());
-        this.extensions = (extensions != null ? extensions : new HashMap<String, Extension>());
+
+        this.emails = emails != null ? ImmutableList.copyOf(emails) : ImmutableList.<Email>of();
+        this.phoneNumbers = phoneNumbers != null ? ImmutableList.copyOf(phoneNumbers) : ImmutableList.<PhoneNumber>of();
+        this.ims = ims != null ? ImmutableList.copyOf(ims) : ImmutableList.<Im>of();
+        this.photos = photos != null ? ImmutableList.copyOf(photos) : ImmutableList.<Photo>of();
+        this.addresses = addresses != null ? ImmutableList.copyOf(addresses) : ImmutableList.<Address>of();
+        this.groups = groups != null ? ImmutableList.copyOf(groups) : ImmutableList.<GroupRef>of();
+        this.entitlements = entitlements != null ? ImmutableList.copyOf(entitlements) : ImmutableList.<Entitlement>of();
+        this.roles = roles != null ? ImmutableList.copyOf(roles) : ImmutableList.<Role>of();
+        this.x509Certificates = x509Certificates != null ? ImmutableList.copyOf(x509Certificates) : ImmutableList.<X509Certificate>of();
+
+        this.extensions = extensions != null ? ImmutableMap.copyOf(extensions) : ImmutableMap.<String, Extension>of();
     }
 
     User(Builder builder) {
@@ -309,7 +310,7 @@ public final class User extends Resource implements Serializable {
      * @return the email addresses of the {@link User}
      */
     public List<Email> getEmails() {
-        return ImmutableList.copyOf(emails);
+        return emails;
     }
 
     /**
@@ -345,7 +346,7 @@ public final class User extends Resource implements Serializable {
      * @return the phone numbers of the {@link User}
      */
     public List<PhoneNumber> getPhoneNumbers() {
-        return ImmutableList.copyOf(phoneNumbers);
+        return phoneNumbers;
     }
 
     /**
@@ -359,7 +360,7 @@ public final class User extends Resource implements Serializable {
      * @return the ims of the {@link User}
      */
     public List<Im> getIms() {
-        return ImmutableList.copyOf(ims);
+        return ims;
     }
 
     /**
@@ -373,7 +374,7 @@ public final class User extends Resource implements Serializable {
      * @return the photo URL's of the {@link User}
      */
     public List<Photo> getPhotos() {
-        return ImmutableList.copyOf(photos);
+        return photos;
     }
 
     /**
@@ -387,7 +388,7 @@ public final class User extends Resource implements Serializable {
      * @return the addresses of the {@link User}
      */
     public List<Address> getAddresses() {
-        return ImmutableList.copyOf(addresses);
+        return addresses;
     }
 
     /**
@@ -401,7 +402,7 @@ public final class User extends Resource implements Serializable {
      * @return a list of all {@link Group}s where the {@link User} is a member of
      */
     public List<GroupRef> getGroups() {
-        return ImmutableList.copyOf(groups);
+        return groups;
     }
 
     /**
@@ -415,7 +416,7 @@ public final class User extends Resource implements Serializable {
      * @return a list of all entitlements of the {@link User}
      */
     public List<Entitlement> getEntitlements() {
-        return ImmutableList.copyOf(entitlements);
+        return entitlements;
     }
 
     /**
@@ -429,7 +430,7 @@ public final class User extends Resource implements Serializable {
      * @return a list of the roles of the {@link User}
      */
     public List<Role> getRoles() {
-        return ImmutableList.copyOf(roles);
+        return roles;
     }
 
     /**
@@ -443,7 +444,7 @@ public final class User extends Resource implements Serializable {
      * @return a list of the certificates of the {@link User}
      */
     public List<X509Certificate> getX509Certificates() {
-        return ImmutableList.copyOf(x509Certificates);
+        return x509Certificates;
     }
 
     /**
@@ -453,7 +454,7 @@ public final class User extends Resource implements Serializable {
      */
     @JsonAnyGetter
     public Map<String, Extension> getExtensions() {
-        return ImmutableMap.copyOf(extensions);
+        return extensions;
     }
 
     /**
@@ -548,16 +549,16 @@ public final class User extends Resource implements Serializable {
                 this.timezone = user.timezone;
                 this.active = user.active;
                 this.password = user.password;
-                this.emails = MoreObjects.firstNonNull(user.emails, this.emails);
-                this.phoneNumbers = MoreObjects.firstNonNull(user.phoneNumbers, this.phoneNumbers);
-                this.ims = MoreObjects.firstNonNull(user.ims, this.ims);
-                this.photos = MoreObjects.firstNonNull(user.photos, this.photos);
-                this.addresses = MoreObjects.firstNonNull(user.addresses, this.addresses);
-                this.groups = MoreObjects.firstNonNull(user.groups, this.groups);
-                this.entitlements = MoreObjects.firstNonNull(user.entitlements, this.entitlements);
-                this.roles = MoreObjects.firstNonNull(user.roles, this.roles);
-                this.x509Certificates = MoreObjects.firstNonNull(user.x509Certificates, this.x509Certificates);
-                this.extensions = MoreObjects.firstNonNull(user.extensions, this.extensions);
+                this.emails.addAll(user.emails);
+                this.phoneNumbers.addAll(user.phoneNumbers);
+                this.ims.addAll(user.ims);
+                this.photos.addAll(user.photos);
+                this.addresses.addAll(user.addresses);
+                this.groups.addAll(user.groups);
+                this.entitlements.addAll(user.entitlements);
+                this.roles.addAll(user.roles);
+                this.x509Certificates.addAll(user.x509Certificates);
+                this.extensions.putAll(user.extensions);
             }
             if (!Strings.isNullOrEmpty(userName)) {
                 this.userName = userName;

--- a/src/main/java/org/osiam/resources/scim/User.java
+++ b/src/main/java/org/osiam/resources/scim/User.java
@@ -43,7 +43,6 @@ import java.util.*;
  * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
  * </p>
  */
-
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public final class User extends Resource implements Serializable {
 

--- a/src/main/java/org/osiam/resources/scim/User.java
+++ b/src/main/java/org/osiam/resources/scim/User.java
@@ -23,7 +23,11 @@
  */
 package org.osiam.resources.scim;
 
-import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
@@ -32,7 +36,13 @@ import com.google.common.collect.ImmutableMap;
 import org.osiam.resources.exception.SCIMDataValidationException;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
 
 /**
  * User resources are meant to enable expression of common User information. It should be possible to express most user


### PR DESCRIPTION
It was possible to change resources, that should actually be immutable, by
using the copy-of constructor of the respective builder class. A simple
test case that was working:

```
def 'Can change immutable User'() {
    given:
    def notSoImmutableUser = new User.Builder('tester').build()

    when:
    new User.Builder(notSoImmutableUser)
            .addExtension(new Extension.Builder('urn:tester').build())

    then:
    notSoImmutableUser.getSchemas().contains('urn:tester')
}
```

This is also true for all other collection-based attributes, like
`emails`, `photos`, etc.

Fix this behavior by:

1. Make a defensive copy of all collections in the resource's
   constructor. Make this copy an `ImmutableList`/`ImmutableSet`. This
   way, only immutable objects are stored in the resource.
2. Copy all elements of collection-based attributes in the copy-of
   constructor of the builders into the builders' own collection.

Remove the creation of `ImmutableList`/`ImmutableSet` in the getters, as
this is not necessary anymore. All fields store immutable objects now.

This PR additionally contains a bunch of small refactorings. See the
individual commits for details:

* Remove constructors that take the builder as parameter
* Remove Jackson annotations from Resource class
* Organize imports
* Remove empty line