### PR TITLE
Deprecate `Group.Builder.setMembers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - `org.osiam.resources.scim.UpdateGroup`
 - `getOperation()` in all multi-valued attribute
 - `setOperation(String)` in all multi-valued attribute builders
+- `org.osiam.resources.scim.Group.Builder.setMembers(Set<MemberRef>)`
 
 ## 1.8 - 2015-12-12
 

--- a/src/main/java/org/osiam/resources/scim/Group.java
+++ b/src/main/java/org/osiam/resources/scim/Group.java
@@ -206,11 +206,9 @@ public final class Group extends Resource implements Serializable {
         }
 
         /**
-         * Sets the list of members as {@link Set} (See {@link Group#getMembers()}).
-         *
-         * @param members the set of members
-         * @return the builder itself
+         * @deprecated Use {@link #removeMembers()} followed by {@link #addMembers(Collection)}. Will be removed in 1.12 or 2.0.
          */
+        @Deprecated
         public Builder setMembers(Set<MemberRef> members) {
             this.members = members;
             return this;


### PR DESCRIPTION
This makes the API consistent with `User.Builder`, where `set…` methods
have been replaced with `add…` and `remove…` methods.