### PR TITLE
Fix some deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - The `BasicUser` class and the method `OsiamConnector.getCurrentUserBasic()`
 - `Group.Builder#setId(String)` and `User.Builder#setId(String)`
 - `Group.Builder#setMeta(Meta)` and `User.Builder#setMeta(Meta)`
+- `org.osiam.resources.scim.Meta.Builder`
 - `User.Builder.Builder(String, User)`
 - `Group.Builder.Builder(String, Group)`
 - `org.osiam.resources.scim.User.Builder.setGroups(List<GroupRef>)`
@@ -39,9 +40,10 @@
 - `org.osiam.client.OsiamConnector.updateGroup(String, UpdateGroup, AccessToken)`
 - `org.osiam.resources.scim.UpdateUser`
 - `org.osiam.resources.scim.UpdateGroup`
-- `getOperation()` in all multi-valued attribute
+- `getOperation()` in all multi-valued attributes
 - `setOperation(String)` in all multi-valued attribute builders
 - `org.osiam.resources.scim.Group.Builder.setMembers(Set<MemberRef>)`
+- `org.osiam.resources.scim.GroupRef.Builder`
 
 ## 1.8 - 2015-12-12
 

--- a/src/main/java/org/osiam/resources/scim/GroupRef.java
+++ b/src/main/java/org/osiam/resources/scim/GroupRef.java
@@ -122,8 +122,9 @@ public final class GroupRef extends MultiValuedAttribute implements Serializable
     }
 
     /**
-     * Builder class that is used to build {@link GroupRef} instances
+     * @deprecated You should not need to create a group object with a client. Will be removed in 1.12 or 2.0.
      */
+    @Deprecated
     public static class Builder extends MultiValuedAttribute.Builder {
 
         private Type type;

--- a/src/main/java/org/osiam/resources/scim/MultiValuedAttribute.java
+++ b/src/main/java/org/osiam/resources/scim/MultiValuedAttribute.java
@@ -279,13 +279,6 @@ public abstract class MultiValuedAttribute implements Serializable {
         }
 
         /**
-         * Sets the operation (See {@link MultiValuedAttribute#getOperation()}).
-         * <p>
-         * Will be automatically set by the {@link UpdateUser}
-         * </p>
-         *
-         * @param operation only "delete" is supported at the moment
-         * @return the builder itself
          * @deprecated Updating with PATCH has been removed in OSIAM 3.0. This method is going to go away with version 1.12 or 2.0.
          */
         @Deprecated
@@ -295,15 +288,9 @@ public abstract class MultiValuedAttribute implements Serializable {
         }
 
         /**
-         * Sets the reference (See {@link MemberRef#getReference()}).
-         * <p>
-         * client info: the Reference value is set by the OSIAM server. If a MultiValuedAttribute which is send to the
-         * OSIAM server has this value filled, the value will be ignored or the action will be rejected.
-         * </p>
-         *
-         * @param reference the scim conform reference to the member
-         * @return the builder itself
+         * @deprecated You should not need to set the reference with a client. Will be removed in 1.12 or 2.0.
          */
+        @Deprecated
         protected Builder setReference(String reference) {
             this.reference = reference;
             return this;


### PR DESCRIPTION
Deprecate `GroupRef`, because it makes no sense to create such objects,
when adding them to a user has no effect and is also deprecated. The
same has been done with `Meta.Builder`.