### PR TITLE
Make `getMe()` compatible with OSIAM 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Features
 
 - Introduce a `getMe()` method to retrieve the currently logged in user
-  from OSIAM 3.0
+  from OSIAM. This is supposed to be the new method to retrieve the logged in
+  user and also works with OSIAM 2.x.
 - `Group.Builder` API has been extended with methods to change the list of members:
 
     - `addMembers(Collection<MemberRef>)`

--- a/docs/working-with-user.md
+++ b/docs/working-with-user.md
@@ -90,18 +90,9 @@ logged user you will retrieve a ConflictException.
 ```sh
 OsiamConnector oConnector = [Retrieving an OsiamConnector](create-osiam-connector.md)
 AccessToken accessToken = [Retrieving an AccessToken](login-and-getting-an-access-token.md#retrieving-an-accesstoken)
-// retrieves the basic data of the actual User
-BasicUser basicUser = oConnector.getCurrentUserBasic(accessToken);
 // retrieves the complete currently logged in User.
-User user = oConnector.getCurrentUser(accessToken);
+User user = oConnector.getMe(accessToken);
 ```
-
-If you only need the basic User data like the userName or the Name, we would
-recommend to use the getCurrentUserBasic method since this one is with more
-performance.
-
-(please consider the possible runtimeException which are explained in the
-Javadoc)
 
 # Retrieve all Users
 

--- a/src/main/java/org/osiam/client/AbstractOsiamService.java
+++ b/src/main/java/org/osiam/client/AbstractOsiamService.java
@@ -408,4 +408,8 @@ abstract class AbstractOsiamService<T extends Resource> {
     int getReadTimeout() {
         return readTimeout;
     }
+
+    Version getVersion() {
+        return version;
+    }
 }

--- a/src/main/java/org/osiam/client/AbstractOsiamService.java
+++ b/src/main/java/org/osiam/client/AbstractOsiamService.java
@@ -75,18 +75,18 @@ import static org.osiam.client.OsiamConnector.objectMapper;
  */
 abstract class AbstractOsiamService<T extends Resource> {
 
-    protected static final String CONNECTION_SETUP_ERROR_STRING = "Cannot connect to OSIAM";
+    static final String CONNECTION_SETUP_ERROR_STRING = "Cannot connect to OSIAM";
 
-    protected static final String AUTHORIZATION = "Authorization";
-    protected static final String BEARER = "Bearer ";
-    protected final WebTarget targetEndpoint;
+    private static final String AUTHORIZATION = "Authorization";
+    static final String BEARER = "Bearer ";
+    final WebTarget targetEndpoint;
     private final Class<T> type;
     private final String typeName;
     private final int connectTimeout;
     private final int readTimeout;
     private final boolean legacySchemas;
 
-    protected AbstractOsiamService(Builder<T> builder) {
+    AbstractOsiamService(Builder<T> builder) {
         type = builder.type;
         typeName = builder.typeName;
         connectTimeout = builder.connectTimeout;
@@ -102,11 +102,11 @@ abstract class AbstractOsiamService<T extends Resource> {
         targetEndpoint = OsiamConnector.getClient().target(builder.endpoint);
     }
 
-    protected static void checkAccessTokenIsNotNull(AccessToken accessToken) {
+    static void checkAccessTokenIsNotNull(AccessToken accessToken) {
         checkNotNull(accessToken, "The given accessToken must not be null.");
     }
 
-    protected T getResource(String id, AccessToken accessToken) {
+    T getResource(String id, AccessToken accessToken) {
         checkArgument(!Strings.isNullOrEmpty(id), "The given id must not be null nor empty.");
         checkAccessTokenIsNotNull(accessToken);
 
@@ -130,12 +130,12 @@ abstract class AbstractOsiamService<T extends Resource> {
         return mapToResource(content);
     }
 
-    protected List<T> getAllResources(AccessToken accessToken) {
+    List<T> getAllResources(AccessToken accessToken) {
         Query query = new QueryBuilder().count(Integer.MAX_VALUE).build();
         return searchResources(query, accessToken).getResources();
     }
 
-    protected SCIMSearchResult<T> searchResources(Query query, AccessToken accessToken) {
+    SCIMSearchResult<T> searchResources(Query query, AccessToken accessToken) {
         checkNotNull(query, "The given query must not be null.");
         checkAccessTokenIsNotNull(accessToken);
 
@@ -174,7 +174,7 @@ abstract class AbstractOsiamService<T extends Resource> {
         }
     }
 
-    protected void deleteResource(String id, AccessToken accessToken) {
+    void deleteResource(String id, AccessToken accessToken) {
         checkArgument(!Strings.isNullOrEmpty(id), "The given id must not be null nor empty.");
         checkAccessTokenIsNotNull(accessToken);
 
@@ -196,7 +196,7 @@ abstract class AbstractOsiamService<T extends Resource> {
         checkAndHandleResponse(content, status, accessToken);
     }
 
-    protected T createResource(T resource, AccessToken accessToken) {
+    T createResource(T resource, AccessToken accessToken) {
         checkNotNull(resource, "The given %s must not be null nor empty.", typeName);
         checkAccessTokenIsNotNull(accessToken);
 
@@ -231,11 +231,11 @@ abstract class AbstractOsiamService<T extends Resource> {
      * @deprecated Updating with PATCH has been removed in OSIAM 3.0. This method is going to go away with version 1.12 or 2.0.
      */
     @Deprecated
-    protected T updateResource(String id, T resource, AccessToken accessToken) {
+    T updateResource(String id, T resource, AccessToken accessToken) {
         return modifyResource(id, resource, "PATCH", accessToken);
     }
 
-    protected T replaceResource(String id, T resource, AccessToken accessToken) {
+    T replaceResource(String id, T resource, AccessToken accessToken) {
         return modifyResource(id, resource, "PUT", accessToken);
     }
 
@@ -275,7 +275,7 @@ abstract class AbstractOsiamService<T extends Resource> {
         return mapToType(content, type);
     }
 
-    protected <U> U mapToType(String content, Class<U> type) {
+    <U> U mapToType(String content, Class<U> type) {
         try {
             if (legacySchemas && (type == User.class || type == Group.class)) {
                 ObjectNode resourceNode = (ObjectNode) objectMapper.readTree(content);
@@ -313,7 +313,7 @@ abstract class AbstractOsiamService<T extends Resource> {
 
     protected abstract String getLegacySchema();
 
-    protected void checkAndHandleResponse(String content, StatusType status, AccessToken accessToken) {
+    void checkAndHandleResponse(String content, StatusType status, AccessToken accessToken) {
         if (status.getFamily() == Family.SUCCESSFUL) {
             return;
         }
@@ -340,19 +340,19 @@ abstract class AbstractOsiamService<T extends Resource> {
 
     }
 
-    protected String extractErrorMessageForbidden(AccessToken accessToken) {
+    private String extractErrorMessageForbidden(AccessToken accessToken) {
         return "Insufficient scopes: " + accessToken.getScopes();
     }
 
-    protected String extractErrorMessageUnauthorized(String content, StatusType status) {
+    private String extractErrorMessageUnauthorized(String content, StatusType status) {
         return extractErrorMessage(content, status);
     }
 
-    protected String extractErrorMessageDefault(String content, StatusType status) {
+    private String extractErrorMessageDefault(String content, StatusType status) {
         return extractErrorMessage(content, status);
     }
 
-    protected String extractErrorMessage(String content, StatusType status) {
+    private String extractErrorMessage(String content, StatusType status) {
         String message;
         if (legacySchemas) {
             message = getScimErrorMessageLegacy(content);
@@ -403,25 +403,25 @@ abstract class AbstractOsiamService<T extends Resource> {
         }
     }
 
-    protected int getConnectTimeout() {
+    int getConnectTimeout() {
         return connectTimeout;
     }
 
-    protected int getReadTimeout() {
+    int getReadTimeout() {
         return readTimeout;
     }
 
-    protected static class Builder<T> {
+    static class Builder<T> {
 
-        protected int connectTimeout = OsiamConnector.DEFAULT_CONNECT_TIMEOUT;
-        protected int readTimeout = OsiamConnector.DEFAULT_READ_TIMEOUT;
-        protected boolean legacySchemas = OsiamConnector.DEFAULT_LEGACY_SCHEMAS;
+        int connectTimeout = OsiamConnector.DEFAULT_CONNECT_TIMEOUT;
+        int readTimeout = OsiamConnector.DEFAULT_READ_TIMEOUT;
+        boolean legacySchemas = OsiamConnector.DEFAULT_LEGACY_SCHEMAS;
         private String endpoint;
         private Class<T> type;
         private String typeName;
 
         @SuppressWarnings("unchecked")
-        protected Builder(String endpoint) {
+        Builder(String endpoint) {
             this.endpoint = endpoint;
             this.type = (Class<T>)
                     ((ParameterizedType) getClass().getGenericSuperclass())

--- a/src/main/java/org/osiam/client/AuthService.java
+++ b/src/main/java/org/osiam/client/AuthService.java
@@ -63,8 +63,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static org.osiam.client.OsiamConnector.objectMapper;
 
 /**
- * The AuthService provides access to the OAuth2 service used to authorize requests. Please use the
- * {@link AuthService.Builder} to construct one.
+ * The AuthService provides access to the OAuth2 service used to authorize requests.
  */
 class AuthService {
 
@@ -79,20 +78,19 @@ class AuthService {
     private final String clientId;
     private final String clientSecret;
     private final String clientRedirectUri;
-    private final int connectionTimeout;
+    private final int connectTimeout;
     private final int readTimeout;
 
     private final WebTarget targetEndpoint;
 
-    private AuthService(Builder builder) {
-        endpoint = builder.endpoint;
-
-        clientId = builder.clientId;
-        clientSecret = builder.clientSecret;
-        clientRedirectUri = builder.clientRedirectUri;
-        connectionTimeout = builder.connectTimeout;
-        readTimeout = builder.readTimeout;
-
+    AuthService(String endpoint, String clientId, String clientSecret, String clientRedirectUri,
+                int connectTimeout, int readTimeout) {
+        this.endpoint = endpoint;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.clientRedirectUri = clientRedirectUri;
+        this.connectTimeout = connectTimeout;
+        this.readTimeout = readTimeout;
         targetEndpoint = OsiamConnector.getClient().target(endpoint);
     }
 
@@ -110,7 +108,7 @@ class AuthService {
                     .request(MediaType.APPLICATION_JSON)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_USERNAME, clientId)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_PASSWORD, clientSecret)
-                    .property(ClientProperties.CONNECT_TIMEOUT, connectionTimeout)
+                    .property(ClientProperties.CONNECT_TIMEOUT, connectTimeout)
                     .property(ClientProperties.READ_TIMEOUT, readTimeout)
                     .post(Entity.form(form));
 
@@ -141,7 +139,7 @@ class AuthService {
                     .request(MediaType.APPLICATION_JSON)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_USERNAME, clientId)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_PASSWORD, clientSecret)
-                    .property(ClientProperties.CONNECT_TIMEOUT, connectionTimeout)
+                    .property(ClientProperties.CONNECT_TIMEOUT, connectTimeout)
                     .property(ClientProperties.READ_TIMEOUT, readTimeout)
                     .post(Entity.form(form));
 
@@ -172,7 +170,7 @@ class AuthService {
                     .request(MediaType.APPLICATION_JSON)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_USERNAME, clientId)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_PASSWORD, clientSecret)
-                    .property(ClientProperties.CONNECT_TIMEOUT, connectionTimeout)
+                    .property(ClientProperties.CONNECT_TIMEOUT, connectTimeout)
                     .property(ClientProperties.READ_TIMEOUT, readTimeout)
                     .post(Entity.form(form));
 
@@ -220,7 +218,7 @@ class AuthService {
                     .request(MediaType.APPLICATION_JSON)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_USERNAME, clientId)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_PASSWORD, clientSecret)
-                    .property(ClientProperties.CONNECT_TIMEOUT, connectionTimeout)
+                    .property(ClientProperties.CONNECT_TIMEOUT, connectTimeout)
                     .property(ClientProperties.READ_TIMEOUT, readTimeout)
                     .post(Entity.form(form));
 
@@ -268,7 +266,7 @@ class AuthService {
                     .request(MediaType.APPLICATION_JSON)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_USERNAME, clientId)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_PASSWORD, clientSecret)
-                    .property(ClientProperties.CONNECT_TIMEOUT, connectionTimeout)
+                    .property(ClientProperties.CONNECT_TIMEOUT, connectTimeout)
                     .property(ClientProperties.READ_TIMEOUT, readTimeout)
                     .header(AUTHORIZATION_HEADER, BEARER + tokenToValidate.getToken())
                     .post(Entity.json(""));
@@ -292,7 +290,7 @@ class AuthService {
                     .request(MediaType.APPLICATION_JSON)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_USERNAME, clientId)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_PASSWORD, clientSecret)
-                    .property(ClientProperties.CONNECT_TIMEOUT, connectionTimeout)
+                    .property(ClientProperties.CONNECT_TIMEOUT, connectTimeout)
                     .property(ClientProperties.READ_TIMEOUT, readTimeout)
                     .header(AUTHORIZATION_HEADER, BEARER + tokenToRevoke.getToken())
                     .post(Entity.json(""));
@@ -314,7 +312,7 @@ class AuthService {
                     .request(MediaType.APPLICATION_JSON)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_USERNAME, clientId)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_PASSWORD, clientSecret)
-                    .property(ClientProperties.CONNECT_TIMEOUT, connectionTimeout)
+                    .property(ClientProperties.CONNECT_TIMEOUT, connectTimeout)
                     .property(ClientProperties.READ_TIMEOUT, readTimeout)
                     .header(AUTHORIZATION_HEADER, BEARER + accessToken.getToken())
                     .post(Entity.json(""));
@@ -344,7 +342,7 @@ class AuthService {
                     .request(MediaType.APPLICATION_JSON)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_USERNAME, clientId)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_PASSWORD, clientSecret)
-                    .property(ClientProperties.CONNECT_TIMEOUT, connectionTimeout)
+                    .property(ClientProperties.CONNECT_TIMEOUT, connectTimeout)
                     .property(ClientProperties.READ_TIMEOUT, readTimeout)
                     .header(AUTHORIZATION_HEADER, BEARER + accessToken.getToken())
                     .post(Entity.json(clientAsString));
@@ -377,7 +375,7 @@ class AuthService {
                     .request(MediaType.APPLICATION_JSON)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_USERNAME, clientId)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_PASSWORD, clientSecret)
-                    .property(ClientProperties.CONNECT_TIMEOUT, connectionTimeout)
+                    .property(ClientProperties.CONNECT_TIMEOUT, connectTimeout)
                     .property(ClientProperties.READ_TIMEOUT, readTimeout)
                     .header(AUTHORIZATION_HEADER, BEARER + accessToken.getToken())
                     .get();
@@ -405,7 +403,7 @@ class AuthService {
                     .request(MediaType.APPLICATION_JSON)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_USERNAME, clientId)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_PASSWORD, clientSecret)
-                    .property(ClientProperties.CONNECT_TIMEOUT, connectionTimeout)
+                    .property(ClientProperties.CONNECT_TIMEOUT, connectTimeout)
                     .property(ClientProperties.READ_TIMEOUT, readTimeout)
                     .header(AUTHORIZATION_HEADER, BEARER + accessToken.getToken())
                     .get();
@@ -434,7 +432,7 @@ class AuthService {
                     .request(MediaType.APPLICATION_JSON)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_USERNAME, clientId)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_PASSWORD, clientSecret)
-                    .property(ClientProperties.CONNECT_TIMEOUT, connectionTimeout)
+                    .property(ClientProperties.CONNECT_TIMEOUT, connectTimeout)
                     .property(ClientProperties.READ_TIMEOUT, readTimeout)
                     .header(AUTHORIZATION_HEADER, BEARER + accessToken.getToken())
                     .delete();
@@ -464,7 +462,7 @@ class AuthService {
                     .request(MediaType.APPLICATION_JSON)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_USERNAME, clientId)
                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_PASSWORD, clientSecret)
-                    .property(ClientProperties.CONNECT_TIMEOUT, connectionTimeout)
+                    .property(ClientProperties.CONNECT_TIMEOUT, connectTimeout)
                     .property(ClientProperties.READ_TIMEOUT, readTimeout)
                     .header(AUTHORIZATION_HEADER, BEARER + accessToken.getToken())
                     .put(Entity.json(clientAsString));
@@ -549,100 +547,5 @@ class AuthService {
 
     private ConnectionInitializationException createGeneralConnectionInitializationException(Throwable e) {
         return new ConnectionInitializationException("Unable to retrieve access token.", e);
-    }
-
-    /**
-     * The Builder class is used to construct instances of the {@link AuthService}.
-     */
-    public static class Builder {
-
-        private String clientId;
-        private String clientSecret;
-        private String endpoint;
-        private String clientRedirectUri;
-        private int connectTimeout = OsiamConnector.DEFAULT_CONNECT_TIMEOUT;
-        private int readTimeout = OsiamConnector.DEFAULT_READ_TIMEOUT;
-
-        /**
-         * Set up the Builder for the construction of an {@link AuthService} instance for the OAuth2 service at the
-         * given endpoint
-         *
-         * @param endpoint The URL at which the OAuth2 service lives.
-         */
-        public Builder(String endpoint) {
-            this.endpoint = endpoint;
-        }
-
-        /**
-         * Add a ClientId to the OAuth2 request
-         *
-         * @param clientId The client-Id
-         * @return The builder itself
-         */
-        public Builder setClientId(String clientId) {
-            this.clientId = clientId;
-            return this;
-        }
-
-        /**
-         * Add a Client redirect URI to the OAuth2 request
-         *
-         * @param clientRedirectUri the clientRedirectUri which is known to OSIAM
-         * @return The builder itself
-         */
-        public Builder setClientRedirectUri(String clientRedirectUri) {
-            this.clientRedirectUri = clientRedirectUri;
-            return this;
-        }
-
-        /**
-         * Add a clientSecret to the OAuth2 request
-         *
-         * @param clientSecret The client secret
-         * @return The builder itself
-         */
-        public Builder setClientSecret(String clientSecret) {
-            this.clientSecret = clientSecret;
-            return this;
-        }
-
-        /**
-         * Set the connect timeout per connector, in milliseconds.
-         * <p/>
-         * <p>
-         * A value of zero (0) is equivalent to an interval of infinity. Default: 0
-         * </p>
-         *
-         * @param connectTimeout the connect timeout per connector, in milliseconds.
-         * @return The builder itself
-         */
-        public Builder withConnectTimeout(int connectTimeout) {
-            this.connectTimeout = connectTimeout;
-            return this;
-        }
-
-        /**
-         * Set the read timeout per connector, in milliseconds.
-         * <p/>
-         * <p>
-         * A value of zero (0) is equivalent to an interval of infinity. Default: 0
-         * </p>
-         *
-         * @param readTimeout the read timeout per connector, in milliseconds.
-         * @return The builder itself
-         */
-        public Builder withReadTimeout(int readTimeout) {
-            this.readTimeout = readTimeout;
-            return this;
-        }
-
-        /**
-         * Construct the {@link AuthService} with the parameters passed to this builder.
-         *
-         * @return An {@link AuthService} configured accordingly.
-         */
-        public AuthService build() {
-            return new AuthService(this);
-        }
     }
 }

--- a/src/main/java/org/osiam/client/AuthService.java
+++ b/src/main/java/org/osiam/client/AuthService.java
@@ -96,7 +96,7 @@ class AuthService {
         targetEndpoint = OsiamConnector.getClient().target(endpoint);
     }
 
-    public AccessToken retrieveAccessToken(Scope... scopes) {
+    AccessToken retrieveAccessToken(Scope... scopes) {
         ensureClientCredentialsAreSet();
         String formattedScopes = getScopesAsString(scopes);
         Form form = new Form();
@@ -125,7 +125,7 @@ class AuthService {
         return getAccessToken(content);
     }
 
-    public AccessToken retrieveAccessToken(String userName, String password, Scope... scopes) {
+    AccessToken retrieveAccessToken(String userName, String password, Scope... scopes) {
         ensureClientCredentialsAreSet();
         String formattedScopes = getScopesAsString(scopes);
         Form form = new Form();
@@ -156,7 +156,7 @@ class AuthService {
         return getAccessToken(content);
     }
 
-    public AccessToken retrieveAccessToken(String authCode) {
+    AccessToken retrieveAccessToken(String authCode) {
         checkArgument(!Strings.isNullOrEmpty(authCode), "The given authentication code can't be null.");
         ensureClientCredentialsAreSet();
 
@@ -200,7 +200,7 @@ class AuthService {
         return scopeBuilder.toString().trim();
     }
 
-    public AccessToken refreshAccessToken(AccessToken accessToken, Scope... scopes) {
+    AccessToken refreshAccessToken(AccessToken accessToken, Scope... scopes) {
         checkArgument(accessToken != null, "The given accessToken code can't be null.");
         checkArgument(accessToken.getRefreshToken() != null,
                 "Unable to perform a refresh_token_grant request without refresh token.");
@@ -239,7 +239,7 @@ class AuthService {
         return getAccessToken(content);
     }
 
-    public URI getAuthorizationUri(Scope... scopes) {
+    URI getAuthorizationUri(Scope... scopes) {
         checkState(!Strings.isNullOrEmpty(clientRedirectUri), "Can't create the login uri: redirect URI was not set.");
         try {
             String formattedScopes = getScopesAsString(scopes);
@@ -258,7 +258,7 @@ class AuthService {
     /**
      * @see OsiamConnector#validateAccessToken(AccessToken)
      */
-    public AccessToken validateAccessToken(AccessToken tokenToValidate) {
+    AccessToken validateAccessToken(AccessToken tokenToValidate) {
         checkNotNull(tokenToValidate, "The tokenToValidate must not be null.");
 
         StatusType status;
@@ -284,7 +284,7 @@ class AuthService {
         return getAccessToken(content);
     }
 
-    public void revokeAccessToken(AccessToken tokenToRevoke) {
+    void revokeAccessToken(AccessToken tokenToRevoke) {
         StatusType status;
         String content;
         try {
@@ -306,7 +306,7 @@ class AuthService {
         checkAndHandleResponse(content, status, tokenToRevoke);
     }
 
-    public void revokeAllAccessTokens(String id, AccessToken accessToken) {
+    void revokeAllAccessTokens(String id, AccessToken accessToken) {
         StatusType status;
         String content;
         try {
@@ -328,7 +328,7 @@ class AuthService {
         checkAndHandleResponse(content, status, accessToken);
     }
 
-    public Client createClient(Client client, AccessToken accessToken) {
+    Client createClient(Client client, AccessToken accessToken) {
         StatusType status;
         String createdClient;
 
@@ -369,7 +369,7 @@ class AuthService {
         }
     }
 
-    public Client getClient(String getClientId, AccessToken accessToken) {
+    Client getClient(String getClientId, AccessToken accessToken) {
         StatusType status;
         String client;
         try {
@@ -397,7 +397,7 @@ class AuthService {
         }
     }
 
-    public List<Client> getClients(AccessToken accessToken) {
+    List<Client> getClients(AccessToken accessToken) {
         StatusType status;
         String clients;
         try {
@@ -426,7 +426,7 @@ class AuthService {
         }
     }
 
-    public void deleteClient(String deleteClientId, AccessToken accessToken) {
+    void deleteClient(String deleteClientId, AccessToken accessToken) {
         StatusType status;
         String content;
         try {
@@ -448,7 +448,7 @@ class AuthService {
         checkAndHandleResponse(content, status, accessToken);
     }
 
-    public Client updateClient(String updateClientId, Client client, AccessToken accessToken) {
+    Client updateClient(String updateClientId, Client client, AccessToken accessToken) {
         StatusType status;
         String clientResponse;
 
@@ -530,7 +530,7 @@ class AuthService {
         }
     }
 
-    protected String extractErrorMessageForbidden(AccessToken accessToken) {
+    private String extractErrorMessageForbidden(AccessToken accessToken) {
         return "Insufficient scopes: " + accessToken.getScopes();
     }
 

--- a/src/main/java/org/osiam/client/OsiamConnector.java
+++ b/src/main/java/org/osiam/client/OsiamConnector.java
@@ -282,8 +282,7 @@ public class OsiamConnector {
      * @throws ForbiddenException                if the scope doesn't allow this request
      * @throws ConnectionInitializationException if no connection to the given OSIAM services could be initialized
      * @throws IllegalStateException             if OSIAM's endpoint(s) are not properly configured
-     * @deprecated Use {@link #getMe(AccessToken)} with OSIAM 3.x. This method
-     *             is going to go away with version 1.12 or 2.0.
+     * @deprecated Use {@link #getMe(AccessToken)}. This method is going to go away with version 1.12 or 2.0.
      */
     @Deprecated
     public User getCurrentUser(AccessToken accessToken) {

--- a/src/main/java/org/osiam/client/OsiamConnector.java
+++ b/src/main/java/org/osiam/client/OsiamConnector.java
@@ -64,9 +64,9 @@ import java.util.List;
 public class OsiamConnector {
 
     public static final ObjectMapper objectMapper = new ObjectMapper();
-    static final int DEFAULT_CONNECT_TIMEOUT = 2500;
-    static final int DEFAULT_READ_TIMEOUT = 5000;
-    static final boolean DEFAULT_LEGACY_SCHEMAS = false;
+    private static final int DEFAULT_CONNECT_TIMEOUT = 2500;
+    private static final int DEFAULT_READ_TIMEOUT = 5000;
+    private static final boolean DEFAULT_LEGACY_SCHEMAS = false;
     private static final int DEFAULT_MAX_CONNECTIONS = 40;
     private static final PoolingHttpClientConnectionManager connectionManager =
             new PoolingHttpClientConnectionManager();
@@ -96,43 +96,29 @@ public class OsiamConnector {
     private OsiamConnector(Builder builder) {
         String authEndpoint;
         String resourceEndpoint;
+        Version version;
         if (!Strings.isNullOrEmpty(builder.endpoint)) {
             authEndpoint = builder.endpoint;
             resourceEndpoint = builder.endpoint;
+            version = Version.OSIAM_3;
         } else {
             authEndpoint = builder.getAuthServiceEndpoint();
             resourceEndpoint = builder.getResourceServiceEndpoint();
+            if (builder.legacySchemas) {
+                version = Version.OSIAM_2_LEGACY_SCHEMAS;
+            } else {
+                version = Version.OSIAM_2;
+            }
         }
 
         if (!Strings.isNullOrEmpty(authEndpoint)) {
-            AuthService.Builder authServiceBuilder = new AuthService.Builder(authEndpoint);
-            if (builder.clientId != null) {
-                authServiceBuilder = authServiceBuilder.setClientId(builder.clientId);
-            }
-            if (builder.clientSecret != null) {
-                authServiceBuilder = authServiceBuilder.setClientSecret(builder.clientSecret);
-            }
-            if (builder.clientRedirectUri != null) {
-                authServiceBuilder = authServiceBuilder.setClientRedirectUri(builder.clientRedirectUri);
-
-            }
-            authService = authServiceBuilder
-                    .withConnectTimeout(builder.connectTimeout)
-                    .withReadTimeout(builder.readTimeout)
-                    .build();
+            authService = new AuthService(authEndpoint, builder.clientId, builder.clientSecret,
+                    builder.clientRedirectUri,builder.connectTimeout,builder.readTimeout);
         }
 
         if (!Strings.isNullOrEmpty(resourceEndpoint)) {
-            userService = new OsiamUserService.Builder(resourceEndpoint)
-                    .withConnectTimeout(builder.connectTimeout)
-                    .withReadTimeout(builder.readTimeout)
-                    .withLegacySchemas(builder.legacySchemas)
-                    .build();
-            groupService = new OsiamGroupService.Builder(resourceEndpoint)
-                    .withConnectTimeout(builder.connectTimeout)
-                    .withReadTimeout(builder.readTimeout)
-                    .withLegacySchemas(builder.legacySchemas)
-                    .build();
+            userService = new OsiamUserService(resourceEndpoint, builder.connectTimeout, builder.readTimeout, version);
+            groupService = new OsiamGroupService(resourceEndpoint, builder.connectTimeout, builder.readTimeout, version);
         }
     }
 

--- a/src/main/java/org/osiam/client/OsiamGroupService.java
+++ b/src/main/java/org/osiam/client/OsiamGroupService.java
@@ -38,7 +38,7 @@ import java.util.List;
 class OsiamGroupService extends AbstractOsiamService<Group> { // NOSONAR - Builder constructs instances of
     // this class
 
-    static final String LEGACY_SCHEMA = "urn:scim:schemas:core:2.0:Group";
+    private static final String LEGACY_SCHEMA = "urn:scim:schemas:core:2.0:Group";
 
     /**
      * The private constructor for the OsiamGroupService. Please use the {@link OsiamGroupService.Builder} to construct
@@ -53,35 +53,35 @@ class OsiamGroupService extends AbstractOsiamService<Group> { // NOSONAR - Build
     /**
      * See {@link OsiamConnector#getGroup(String, AccessToken)}
      */
-    public Group getGroup(String id, AccessToken accessToken) {
+    Group getGroup(String id, AccessToken accessToken) {
         return getResource(id, accessToken);
     }
 
     /**
      * See {@link OsiamConnector#getAllGroups(AccessToken)}
      */
-    public List<Group> getAllGroups(AccessToken accessToken) {
+    List<Group> getAllGroups(AccessToken accessToken) {
         return getAllResources(accessToken);
     }
 
     /**
      * See {@link OsiamConnector#searchGroups(Query, AccessToken)}
      */
-    public SCIMSearchResult<Group> searchGroups(Query query, AccessToken accessToken) {
+    SCIMSearchResult<Group> searchGroups(Query query, AccessToken accessToken) {
         return searchResources(query, accessToken);
     }
 
     /**
      * See {@link OsiamConnector#deleteUser(String, AccessToken)}
      */
-    public void deleteGroup(String id, AccessToken accessToken) {
+    void deleteGroup(String id, AccessToken accessToken) {
         deleteResource(id, accessToken);
     }
 
     /**
      * See {@link OsiamConnector#createGroup(Group, AccessToken)}
      */
-    public Group createGroup(Group group, AccessToken accessToken) {
+    Group createGroup(Group group, AccessToken accessToken) {
         return createResource(group, accessToken);
     }
 
@@ -90,7 +90,7 @@ class OsiamGroupService extends AbstractOsiamService<Group> { // NOSONAR - Build
      * @deprecated Updating with PATCH has been removed in OSIAM 3.0. This method is going to go away with version 1.12 or 2.0.
      */
     @Deprecated
-    public Group updateGroup(String id, UpdateGroup updateGroup, AccessToken accessToken) {
+    Group updateGroup(String id, UpdateGroup updateGroup, AccessToken accessToken) {
         return updateResource(id, updateGroup.getScimConformUpdateGroup(), accessToken);
     }
 
@@ -99,14 +99,14 @@ class OsiamGroupService extends AbstractOsiamService<Group> { // NOSONAR - Build
      * @deprecated Updating with PATCH has been removed in OSIAM 3.0. This method is going to go away with version 1.12 or 2.0.
      */
     @Deprecated
-    public Group updateGroup(String id, Group group, AccessToken accessToken) {
+    Group updateGroup(String id, Group group, AccessToken accessToken) {
         return updateResource(id, group, accessToken);
     }
 
     /**
      * See {@link OsiamConnector#replaceGroup(String, Group, AccessToken)}
      */
-    public Group replaceGroup(String id, Group group, AccessToken accessToken) {
+    Group replaceGroup(String id, Group group, AccessToken accessToken) {
         return replaceResource(id, group, accessToken);
     }
 

--- a/src/main/java/org/osiam/client/OsiamGroupService.java
+++ b/src/main/java/org/osiam/client/OsiamGroupService.java
@@ -33,21 +33,14 @@ import java.util.List;
 
 /**
  * OsiamGroupService provides all methods necessary to manipulate the {@link Group} resources registered in the given
- * OSIAM installation. For the construction of an instance please use the {@link OsiamGroupService.Builder}
+ * OSIAM installation.
  */
-class OsiamGroupService extends AbstractOsiamService<Group> { // NOSONAR - Builder constructs instances of
-    // this class
+class OsiamGroupService extends AbstractOsiamService<Group> {
 
     private static final String LEGACY_SCHEMA = "urn:scim:schemas:core:2.0:Group";
 
-    /**
-     * The private constructor for the OsiamGroupService. Please use the {@link OsiamGroupService.Builder} to construct
-     * one.
-     *
-     * @param builder The Builder to build the OsiamGroupService from
-     */
-    private OsiamGroupService(Builder builder) {
-        super(builder);
+    OsiamGroupService(String endpoint, int connectTimeout, int readTimeout, Version version) {
+        super(endpoint, Group.class, connectTimeout, readTimeout, version);
     }
 
     /**
@@ -118,74 +111,5 @@ class OsiamGroupService extends AbstractOsiamService<Group> { // NOSONAR - Build
     @Override
     protected String getLegacySchema() {
         return LEGACY_SCHEMA;
-    }
-
-    /**
-     * See {@link OsiamConnector.Builder}
-     */
-    public static class Builder extends AbstractOsiamService.Builder<Group> {
-
-        /**
-         * Set up the Builder for the construction of an {@link OsiamGroupService} instance for the OSIAM service at the
-         * given endpoint
-         *
-         * @param endpoint The URL at which OSIAM lives.
-         */
-        public Builder(String endpoint) {
-            super(endpoint);
-        }
-
-        /**
-         * Set the connect timeout per connector, in milliseconds.
-         * <p/>
-         * <p>
-         * A value of zero (0) is equivalent to an interval of infinity. Default: 2500
-         * </p>
-         *
-         * @param connectTimeout the connect timeout per connector, in milliseconds.
-         * @return The builder itself
-         */
-        public Builder withConnectTimeout(int connectTimeout) {
-            this.connectTimeout = connectTimeout;
-            return this;
-        }
-
-        /**
-         * Set the read timeout per connector, in milliseconds.
-         * <p/>
-         * <p>
-         * A value of zero (0) is equivalent to an interval of infinity. Default: 5000
-         * </p>
-         *
-         * @param readTimeout the read timeout per connector, in milliseconds.
-         * @return The builder itself
-         */
-        public Builder withReadTimeout(int readTimeout) {
-            this.readTimeout = readTimeout;
-            return this;
-        }
-
-        /**
-         * Configures the group service to use legacy schemas, i.e. schemas that were defined
-         * before SCIM 2 draft 09.
-         *
-         * <p/>This enables compatibility with OSIAM releases up to version 2.3
-         * (resource-server 2.2). This behavior is not enabled by default. Set it to `true` if you
-         * connect to an OSIAM version <= 2.3 and, please, update to 2.5 or later immediately.
-         *
-         * @param legacySchemas should legacy schemas be used
-         * @return The builder itself
-         */
-        public Builder withLegacySchemas(boolean legacySchemas) {
-            this.legacySchemas = legacySchemas;
-            return this;
-        }
-
-        /**
-         * See {@link OsiamConnector.Builder#build()}
-         */
-        public OsiamGroupService build() {
-            return new OsiamGroupService(this);
-        }
     }
 }

--- a/src/main/java/org/osiam/client/OsiamUserService.java
+++ b/src/main/java/org/osiam/client/OsiamUserService.java
@@ -105,9 +105,9 @@ class OsiamUserService extends AbstractOsiamService<User> {
      * See {@link OsiamConnector#getMe(AccessToken)}
      */
     User getMe(AccessToken accessToken) {
-        String content = getMeResource(accessToken);
-
-        return mapToType(content, User.class);
+        return getVersion() == Version.OSIAM_3
+                ? mapToType(getMeResource(accessToken), User.class)
+                : getUser(getCurrentUserBasic(accessToken).getId(), accessToken);
     }
 
     /**

--- a/src/main/java/org/osiam/client/OsiamUserService.java
+++ b/src/main/java/org/osiam/client/OsiamUserService.java
@@ -42,20 +42,14 @@ import java.util.List;
 
 /**
  * The OsiamUserService provides all methods necessary to manipulate the User-entries registered in the given OSIAM
- * installation. For the construction of an instance please use the included {@link OsiamUserService.Builder}
+ * installation.
  */
 class OsiamUserService extends AbstractOsiamService<User> {
 
     static final String LEGACY_SCHEMA = "urn:scim:schemas:core:2.0:User";
 
-    /**
-     * The private constructor for the OsiamUserService. Please use the {@link OsiamUserService.Builder} to construct
-     * one.
-     *
-     * @param builder a Builder to build the service from
-     */
-    private OsiamUserService(Builder builder) {
-        super(builder);
+    OsiamUserService(String endpoint, int connectTimeout, int readTimeout, Version version) {
+        super(endpoint, User.class, connectTimeout, readTimeout, version);
     }
 
     /**
@@ -199,74 +193,5 @@ class OsiamUserService extends AbstractOsiamService<User> {
 
         checkAndHandleResponse(content, status, accessToken);
         return content;
-    }
-
-    /**
-     * See {@link OsiamConnector.Builder}
-     */
-    public static class Builder extends AbstractOsiamService.Builder<User> {
-
-        /**
-         * Set up the Builder for the construction of an {@link OsiamUserService} instance for the OSIAM service at the
-         * given endpoint
-         *
-         * @param endpoint The URL at which OSIAM lives.
-         */
-        public Builder(String endpoint) {
-            super(endpoint);
-        }
-
-        /**
-         * Set the connect timeout per connector, in milliseconds.
-         * <p/>
-         * <p>
-         * A value of zero (0) is equivalent to an interval of infinity. Default: 2500
-         * </p>
-         *
-         * @param connectTimeout the connect timeout per connector, in milliseconds.
-         * @return The builder itself
-         */
-        public Builder withConnectTimeout(int connectTimeout) {
-            this.connectTimeout = connectTimeout;
-            return this;
-        }
-
-        /**
-         * Set the read timeout per connector, in milliseconds.
-         * <p/>
-         * <p>
-         * A value of zero (0) is equivalent to an interval of infinity. Default: 5000
-         * </p>
-         *
-         * @param readTimeout the read timeout per connector, in milliseconds.
-         * @return The builder itself
-         */
-        public Builder withReadTimeout(int readTimeout) {
-            this.readTimeout = readTimeout;
-            return this;
-        }
-
-        /**
-         * Configures the user service to use legacy schemas, i.e. schemas that were defined before
-         * SCIM 2 draft 09.
-         * <p>
-         * <p/>This enables compatibility with OSIAM releases up to version 2.3
-         * (resource-server 2.2). This behavior is not enabled by default. Set it to `true` if you
-         * connect to an OSIAM version <= 2.3 and, please, update to 2.5 or later immediately.
-         *
-         * @param legacySchemas should legacy schemas be used
-         * @return The builder itself
-         */
-        public Builder withLegacySchemas(boolean legacySchemas) {
-            this.legacySchemas = legacySchemas;
-            return this;
-        }
-
-        /**
-         * See {@link OsiamConnector.Builder#build()}
-         */
-        public OsiamUserService build() {
-            return new OsiamUserService(this);
-        }
     }
 }

--- a/src/main/java/org/osiam/client/OsiamUserService.java
+++ b/src/main/java/org/osiam/client/OsiamUserService.java
@@ -61,7 +61,7 @@ class OsiamUserService extends AbstractOsiamService<User> {
     /**
      * See {@link OsiamConnector#getUser(String, AccessToken)}
      */
-    public User getUser(String id, AccessToken accessToken) {
+    User getUser(String id, AccessToken accessToken) {
         return getResource(id, accessToken);
     }
 
@@ -72,7 +72,7 @@ class OsiamUserService extends AbstractOsiamService<User> {
      *             is going to go away with version 1.12 or 2.0.
      */
     @Deprecated
-    public BasicUser getCurrentUserBasic(AccessToken accessToken) {
+    BasicUser getCurrentUserBasic(AccessToken accessToken) {
         checkAccessTokenIsNotNull(accessToken);
 
         StatusType status;
@@ -102,7 +102,7 @@ class OsiamUserService extends AbstractOsiamService<User> {
      *             is going to go away with version 1.12 or 2.0.
      */
     @Deprecated
-    public User getCurrentUser(AccessToken accessToken) {
+    User getCurrentUser(AccessToken accessToken) {
         BasicUser basicUser = getCurrentUserBasic(accessToken);
         return getResource(basicUser.getId(), accessToken);
     }
@@ -110,7 +110,7 @@ class OsiamUserService extends AbstractOsiamService<User> {
     /**
      * See {@link OsiamConnector#getMe(AccessToken)}
      */
-    public User getMe(AccessToken accessToken) {
+    User getMe(AccessToken accessToken) {
         String content = getMeResource(accessToken);
 
         return mapToType(content, User.class);
@@ -119,28 +119,28 @@ class OsiamUserService extends AbstractOsiamService<User> {
     /**
      * See {@link OsiamConnector#getAllUsers(AccessToken)}
      */
-    public List<User> getAllUsers(AccessToken accessToken) {
+    List<User> getAllUsers(AccessToken accessToken) {
         return super.getAllResources(accessToken);
     }
 
     /**
      * See {@link OsiamConnector#searchUsers(Query, AccessToken)}
      */
-    public SCIMSearchResult<User> searchUsers(Query query, AccessToken accessToken) {
+    SCIMSearchResult<User> searchUsers(Query query, AccessToken accessToken) {
         return searchResources(query, accessToken);
     }
 
     /**
      * See {@link OsiamConnector#deleteUser(String, AccessToken)}
      */
-    public void deleteUser(String id, AccessToken accessToken) {
+    void deleteUser(String id, AccessToken accessToken) {
         deleteResource(id, accessToken);
     }
 
     /**
      * See {@link OsiamConnector#createUser(User, AccessToken)}
      */
-    public User createUser(User user, AccessToken accessToken) {
+    User createUser(User user, AccessToken accessToken) {
         return createResource(user, accessToken);
     }
 
@@ -149,7 +149,7 @@ class OsiamUserService extends AbstractOsiamService<User> {
      * @deprecated Updating with PATCH has been removed in OSIAM 3.0. This method is going to go away with version 1.12 or 2.0.
      */
     @Deprecated
-    public User updateUser(String id, UpdateUser updateUser, AccessToken accessToken) {
+    User updateUser(String id, UpdateUser updateUser, AccessToken accessToken) {
         if (updateUser == null) {
             throw new IllegalArgumentException("The given updateUser can't be null.");
         }
@@ -159,7 +159,7 @@ class OsiamUserService extends AbstractOsiamService<User> {
     /**
      * See {@link OsiamConnector#replaceUser(String, User, AccessToken)}
      */
-    public User replaceUser(String id, User user, AccessToken accessToken) {
+    User replaceUser(String id, User user, AccessToken accessToken) {
         if (user == null) {
             throw new InvalidAttributeException("The given User can't be null.");
         }

--- a/src/main/java/org/osiam/client/Version.java
+++ b/src/main/java/org/osiam/client/Version.java
@@ -23,27 +23,6 @@
  */
 package org.osiam.client;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import static org.junit.Assert.fail;
-
-public class OsiamUserMeTest {
-
-    final static private String ENDPOINT = "http://localhost:9090/osiam";
-
-    private OsiamUserService service;
-
-    @Before
-    public void setUp() throws Exception {
-        service = new OsiamUserService(ENDPOINT, 0, 0, null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void accessToken_is_null_by_getting_me_user_raises_exception() throws Exception {
-        service.getCurrentUser(null);
-
-        fail("Exception expected");
-    }
-
+enum Version {
+    OSIAM_3, OSIAM_2, OSIAM_2_LEGACY_SCHEMAS
 }

--- a/src/test/java/org/osiam/client/OsiamGroupServiceTest.java
+++ b/src/test/java/org/osiam/client/OsiamGroupServiceTest.java
@@ -44,7 +44,7 @@ public class OsiamGroupServiceTest {
 
     @Before
     public void setUp() throws IOException {
-        service = new OsiamGroupService.Builder(ENDPOINT).build();
+        service = new OsiamGroupService(ENDPOINT, 0, 0, null);
         searchedId = GROUP_ID_STRING;
         accessToken = new AccessToken.Builder("c5d116cb-2758-4e7c-9aca-4a115bc4f19e")
                 .setExpiresAt(new Date(System.currentTimeMillis() * 2))

--- a/src/test/java/org/osiam/client/OsiamUserEditTest.java
+++ b/src/test/java/org/osiam/client/OsiamUserEditTest.java
@@ -38,7 +38,7 @@ public class OsiamUserEditTest {
     private static final String UPDATE_USER_ID = "94bbe688-4b1e-4e4e-80e7-e5ba5c4d6db4";
 
     private AccessToken accessToken;
-    private OsiamUserService service = new OsiamUserService.Builder(ENDPOINT).build();
+    private OsiamUserService service = new OsiamUserService(ENDPOINT, 0, 0, null);
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/osiam/client/OsiamUserServiceTest.java
+++ b/src/test/java/org/osiam/client/OsiamUserServiceTest.java
@@ -57,7 +57,7 @@ public class OsiamUserServiceTest {
 
     @Before
     public void setUp() throws Exception {
-        service = new OsiamUserService.Builder(endpoint).build();
+        service = new OsiamUserService(endpoint, 0, 0, null);
         searchedID = USER_ID;
         accessToken = new AccessToken.Builder("c5d116cb-2758-4e7c-9aca-4a115bc4f19e")
                 .setExpiresAt(new Date(System.currentTimeMillis() * 2))


### PR DESCRIPTION
OSIAM 2.x will still be supported for some time, so it makes sense to
provide a uniform interface for all users. Also, the self-admin uses
`getMe()` and must be compatible with 2.x and 3.x, too.