### PR TITLE
Change version to 'latest-SNAPSHOT'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,14 @@ Please update to OSIAM 3.0 as soon as possible.
 
 - The scim-schema has been completely merged into this project. It is now obsolete.
 - `Address` has a `display` property now.
-- The user name can now be set via the builder
-- The group's display name can now be set via the builder
+- The user name can now be set via the builder.
+- The group's display name can now be set via the builder.
 - Properties of a user's name attribute can be easily updated now.
 
 ### Changes
 
 - Jackson has been shaded, so that the only dependency left of the connector is Guava.
+- The current snapshot version is now `latest-SNAPSHOT` for all upcoming versions.
 
 ### Fixes
 
@@ -33,9 +34,9 @@ Please update to OSIAM 3.0 as soon as possible.
   to be immutable.
 - An Extension could be changed by using the copy-of constructor of its builder, though it was supposed
   to be immutable.
-- A `400 BAD REQUEST` response now creates a `BadRequestException` instead of a `ConflictException` 
+- A `400 BAD REQUEST` response now creates a `BadRequestException` instead of a `ConflictException`.
 - Return the right builder type in `Photo.Builder#setValue(String)`.
-- Replacing a group with PUT was actually updating it with PATCH
+- Replacing a group with PUT was actually updating it with PATCH.
 - Extensions defined in the `schemas` attribute of a resource will be ignored, if the resource contains
   no data for the extension, instead of raising an exception.
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.osiam</groupId>
     <artifactId>connector4java</artifactId>
-    <version>1.9-SNAPSHOT</version>
+    <version>latest-SNAPSHOT</version>
 
     <name>OSIAM Connector 4 Java</name>
     <description>Native Java API to connect to the REST based OSIAM services</description>


### PR DESCRIPTION
This has to be done for the new release process to work. Otherwise we
would have to increase the version somehow after release by Circle CI or
worse: manually. There is no need to fetch a snapshot after a release,
because the release contains the exact same code as the last snapshot.
So having a universally working snapshot version, like
'latest-SNAPSHOT', should do no harm, but eases the burden of
maintaining the right version between releases.