### PR TITLE
Update deprecations from scim-schema

### DIFF
--- a/src/main/java/org/osiam/resources/helper/SCIMHelper.java
+++ b/src/main/java/org/osiam/resources/helper/SCIMHelper.java
@@ -31,6 +31,7 @@ import org.osiam.resources.scim.User;
  * This class is a collection of different helper methods around the scim schema context
  * This class has been deprecated. If You want to use the only method it contains please see
  * {@link User#getPrimaryOrFirstEmail()}
+ * @deprecated Will be removed in 1.11 or 2.0.
  */
 @Deprecated
 public class SCIMHelper {
@@ -44,7 +45,7 @@ public class SCIMHelper {
      *
      * @param user a {@link User} with a possible email
      * @return an email if found
-     * @deprecated Please use the method {@link User#getPrimaryOrFirstEmail()}
+     * @deprecated Please use the method {@link User#getPrimaryOrFirstEmail()}. Will be removed in 1.11 or 2.0.
      */
     @Deprecated
     public static Optional<Email> getPrimaryOrFirstEmail(User user) {

--- a/src/main/java/org/osiam/resources/helper/UserDeserializer.java
+++ b/src/main/java/org/osiam/resources/helper/UserDeserializer.java
@@ -72,7 +72,7 @@ public class UserDeserializer extends StdDeserializer<User> {
 
     /**
      * @deprecated Use {@link UserDeserializer#UserDeserializer()} or
-     * {@link UserDeserializer#UserDeserializer(String)}. Will be removed in 1.9 or 2.0.
+     * {@link UserDeserializer#UserDeserializer(String)}. Will be removed in 1.11 or 2.0.
      */
     public UserDeserializer(Class<?> valueClass) {
         super(valueClass);

--- a/src/main/java/org/osiam/resources/scim/Constants.java
+++ b/src/main/java/org/osiam/resources/scim/Constants.java
@@ -24,31 +24,29 @@
 package org.osiam.resources.scim;
 
 /**
- * Some needed Constants
- *
- * @deprecated This interface has been deprecated and is going to be removed in a future release.
+ * @deprecated These constants have been moved to their corresponding classes. Will be removed in 1.11 or 2.0.
  */
 @Deprecated
 public interface Constants {
 
     /**
-     * @deprecated please use {@link User}.SCHEMA
+     * @deprecated Please use {@link User}.SCHEMA. Will be removed in 1.11 or 2.0.
      */
     String USER_CORE_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";
     /**
-     * @deprecated please use {@link Group}.SCHEMA
+     * @deprecated Please use {@link Group}.SCHEMA. Will be removed in 1.11 or 2.0.
      */
     String GROUP_CORE_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:Group";
     /**
-     * @deprecated please use {@link SCIMSearchResult}.SCHEMA
+     * @deprecated Please use {@link SCIMSearchResult}.SCHEMA. Will be removed in 1.11 or 2.0.
      */
     String LIST_RESPONSE_CORE_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:ListResponse";
     /**
-     * @deprecated This constant is going to be removed soon.
+     * @deprecated This constant is going to be removed in 1.11 or 2.0.
      */
     String SERVICE_PROVIDER_CORE_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig";
     /**
-     * @deprecated This constant is going to be removed soon.
+     * @deprecated This constant is going to be removed in 1.11 or 2.0.
      */
     int MAX_RESULT = 100;
 }

--- a/src/main/java/org/osiam/resources/scim/Group.java
+++ b/src/main/java/org/osiam/resources/scim/Group.java
@@ -185,7 +185,7 @@ public final class Group extends Resource implements Serializable {
 
         /**
          * @deprecated Don't use this method - let the extensions add their schema themselves. Will be removed in
-         * version 1.8 or 2.0
+         * version 1.10 or 2.0
          */
         @Override
         @Deprecated

--- a/src/main/java/org/osiam/resources/scim/Resource.java
+++ b/src/main/java/org/osiam/resources/scim/Resource.java
@@ -144,7 +144,7 @@ public abstract class Resource implements Serializable {
 
         /**
          * @deprecated Don't use this method - let the extensions add their schema themselves. Will be removed in
-         * version 1.8 or 2.0
+         * version 1.10 or 2.0
          */
         @Deprecated
         public Builder setSchemas(Set<String> schemas) {

--- a/src/main/java/org/osiam/resources/scim/User.java
+++ b/src/main/java/org/osiam/resources/scim/User.java
@@ -1206,7 +1206,7 @@ public final class User extends Resource implements Serializable {
 
         /**
          * @deprecated Don't use this method - let the extensions add their schema themselves. Will be removed in
-         * version 1.8 or 2.0
+         * version 1.10 or 2.0
          */
         @Override
         @Deprecated


### PR DESCRIPTION
With the merge of the scim-schema, deprecations have also been merged,
but were not aligned to the version of the connector. The alignment is
as follows: scim-schema 1.6 is the same as connector 1.8, so all "removal
versions" have to be increased by 2. Update deprecations without a
removal version on a best effort basis.